### PR TITLE
Ensure we use the forwarded host header when it exists

### DIFF
--- a/services/nginx/api_gateway.conf
+++ b/services/nginx/api_gateway.conf
@@ -6,7 +6,11 @@ server {
     ssl_certificate certs/cert.pem;
     ssl_certificate_key certs/key.pem;
     include      api_conf.d/*.conf;
-    set          $proxy_host $host;
+    set          $proxy_host $http_x_rh_insights_forwarded_host;
+
+    if ($proxy_host = "") {
+        set $proxy_host $host;
+    }
 
     auth_request     /auth/;
     auth_request_set $login_url $upstream_http_login_url;
@@ -38,6 +42,6 @@ server {
 
     error_page 401 = @error401;
     location @error401 {
-        return 302 https://$host$login_url;
+        return 302 https://$proxy_host$login_url;
     }
 }

--- a/services/web/app.py
+++ b/services/web/app.py
@@ -39,7 +39,7 @@ class SAMLView(views.MethodView):
         url_data = urlparse(request.url)
         return {
             "https": "on" if request.scheme == "https" else "off",
-            "http_host": request.headers.get("X-Forwarded-Host", ""),
+            "http_host": request.headers.get("X-Forwarded-Host", request.headers.get("Host", "")),
             "server_port": url_data.port,
             "script_name": request.path,
             "get_data": request.args.copy(),

--- a/services/web/app.py
+++ b/services/web/app.py
@@ -39,7 +39,7 @@ class SAMLView(views.MethodView):
         url_data = urlparse(request.url)
         return {
             "https": "on" if request.scheme == "https" else "off",
-            "http_host": request.host,
+            "http_host": request.headers.get("X-Forwarded-Host"),
             "server_port": url_data.port,
             "script_name": request.path,
             "get_data": request.args.copy(),

--- a/services/web/app.py
+++ b/services/web/app.py
@@ -39,7 +39,7 @@ class SAMLView(views.MethodView):
         url_data = urlparse(request.url)
         return {
             "https": "on" if request.scheme == "https" else "off",
-            "http_host": request.headers.get("X-Forwarded-Host"),
+            "http_host": request.headers.get("X-Forwarded-Host", ""),
             "server_port": url_data.port,
             "script_name": request.path,
             "get_data": request.args.copy(),


### PR DESCRIPTION
With Fakamai integration, we receive a header: `x-rh-insights-forwarded-host`
which contains the actual hostname we need to set for our SP config, to match
the response from the IdP. In the case of CI for instance, this would be:
ci.internal.cloud.redhat.com

We need to ensure we set this for the `$proxy_host` value in order for our SP
to behave correctly, and for our redirect on `401` to use the correct hostname.

Locally, when this header is _not_ set, we should default this to use the actual
host.