### PR TITLE
Configure routes from config map

### DIFF
--- a/dev-backends.yml
+++ b/dev-backends.yml
@@ -3,3 +3,6 @@
   origin: http://web:5000/api/ping-service
   auth:
     saml: "True"
+- name: healthcheck
+  route: /_healthcheck/
+  origin: http://web:5000/_healthcheck/

--- a/dev-backends.yml
+++ b/dev-backends.yml
@@ -1,0 +1,5 @@
+- name: ping
+  route: /api/ping-service
+  origin: http://web:5000/api/ping-service
+  auth:
+    saml: "True"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     privileged: true
     volumes:
       - "./services/web:/usr/src/app/"
+      - "./dev-backends.yml:/etc/turnpike/backends.yml"
     command: ["flask", "run", "--reload"]
     networks:
       mynet:
@@ -23,6 +24,8 @@ services:
     depends_on:
       - web
     hostname: nginx
+    volumes:
+      - "./dev-backends.yml:/etc/turnpike/backends.yml"
     networks:
       mynet:
         aliases:

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -7,5 +7,6 @@ RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx && \
     apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/*
 
 COPY . /etc/nginx
+RUN chmod g+rwx /etc/nginx
 COPY turnpike-entrypoint.sh /docker-entrypoint.d/turnpike-entrypoint.sh
 ENV BACKENDS_CONFIG_MAP=/etc/turnpike/backends.yml

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -1,6 +1,11 @@
 FROM nginx
 
 # support running as an arbitrary user which belogs to the root group
-RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx
+RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx && \
+    apt-get update && \
+    apt-get install --no-install-recommends --no-install-suggests -y python3-jinja2 python3-yaml python3-minimal && \
+    apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/*
 
 COPY . /etc/nginx
+COPY turnpike-entrypoint.sh /docker-entrypoint.d/turnpike-entrypoint.sh
+ENV BACKENDS_CONFIG_MAP=/etc/turnpike/backends.yml

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -7,6 +7,6 @@ RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx && \
     apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/*
 
 COPY . /etc/nginx
-RUN chmod g+rwx /etc/nginx
+RUN chmod g+rwx /etc/nginx/api_conf.d
 COPY turnpike-entrypoint.sh /docker-entrypoint.d/turnpike-entrypoint.sh
 ENV BACKENDS_CONFIG_MAP=/etc/turnpike/backends.yml

--- a/services/nginx/api_backends.conf
+++ b/services/nginx/api_backends.conf
@@ -1,9 +1,0 @@
-# add an upstream entry for new API services:
-#
-# upstream acme_service {
-#     server http://acme.acme-qa.svc.cluster.local:8080;
-# }
-
-upstream ping_api {
-  server web:5000;
-}

--- a/services/nginx/api_conf.d/ping_api.conf
+++ b/services/nginx/api_conf.d/ping_api.conf
@@ -1,4 +1,0 @@
-location /api/ping-service {
-    set        $upstream ping_api;
-    proxy_pass http://$upstream$request_uri;
-}

--- a/services/nginx/api_gateway.conf
+++ b/services/nginx/api_gateway.conf
@@ -1,5 +1,3 @@
-include api_backends.conf;
-
 server {
     listen       8443 ssl default_server;
     server_name  nginx;
@@ -7,9 +5,6 @@ server {
     ssl_certificate_key certs/key.pem;
     include      api_conf.d/*.conf;
     set          $proxy_host $host;
-
-    auth_request     /auth/;
-    auth_request_set $login_url $upstream_http_login_url;
 
     location = /auth/ {
         internal;

--- a/services/nginx/backend_template.conf.j2
+++ b/services/nginx/backend_template.conf.j2
@@ -1,0 +1,13 @@
+    location {{ route }} {
+        {% if auth %}
+            auth_request     /auth/;
+            auth_request_set $login_url $upstream_http_login_url;
+        {% endif %}
+        proxy_pass              {{ origin }};
+        proxy_set_header        X-Original-URI $request_uri;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-Host $proxy_host;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Port 443;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+    }

--- a/services/nginx/build-backends.py
+++ b/services/nginx/build-backends.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import warnings
+
+import jinja2
+import yaml
+import yaml.error
+
+
+# Do not include leading or trailing slashes in these routes
+FORBIDDEN_ROUTES = ["", "saml", "auth"]
+
+
+def main(args):
+    try:
+        with open(args.config_map_path) as ifs:
+            backends = yaml.safe_load(ifs)
+    except OSError:
+        raise Exception(f"Error opening config map at {args.config_map_path}")
+    except yaml.error.YAMLError as e:
+        raise Exception(f"Error parsing config map as YAML: {e}")
+
+    assert isinstance(backends, list), "YAML file does not contain a list of backends."
+
+    with open("/etc/nginx/backend_template.conf.j2") as ifs:
+        template = jinja2.Template(ifs.read())
+    for backend in backends:
+        name = backend["name"]
+        print(f"Processing backend configuration for {name}")
+        route = backend["route"]
+        if route.strip("/") in FORBIDDEN_ROUTES:
+            warnings.warn(f"Forbidden route found in config map: {route} - skipping.")
+
+        with open(os.path.join(args.nginx_confd_dir, f"{name}.conf"), "w") as ofs:
+            ofs.write(template.render(**backend))
+    print("Done.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build nginx backend configurations from config map")
+    parser.add_argument("config_map_path", help="Path to the config map with routes")
+    parser.add_argument("nginx_confd_dir", help="Path to output nginx conf.d files")
+
+    args = parser.parse_args()
+    main(args)

--- a/services/nginx/build-backends.py
+++ b/services/nginx/build-backends.py
@@ -28,14 +28,14 @@ def main(args):
         template = jinja2.Template(ifs.read())
     for backend in backends:
         name = backend["name"]
-        print(f"Processing backend configuration for {name}")
+        app.logger.info(f"Processing backend configuration for {name}")
         route = backend["route"]
         if route.strip("/") in FORBIDDEN_ROUTES:
             warnings.warn(f"Forbidden route found in config map: {route} - skipping.")
 
         with open(os.path.join(args.nginx_confd_dir, f"{name}.conf"), "w") as ofs:
             ofs.write(template.render(**backend))
-    print("Done.")
+    app.logger.info("Done.")
 
 
 if __name__ == "__main__":

--- a/services/nginx/build-backends.py
+++ b/services/nginx/build-backends.py
@@ -28,14 +28,14 @@ def main(args):
         template = jinja2.Template(ifs.read())
     for backend in backends:
         name = backend["name"]
-        app.logger.info(f"Processing backend configuration for {name}")
+        print(f"Processing backend configuration for {name}")
         route = backend["route"]
         if route.strip("/") in FORBIDDEN_ROUTES:
             warnings.warn(f"Forbidden route found in config map: {route} - skipping.")
 
         with open(os.path.join(args.nginx_confd_dir, f"{name}.conf"), "w") as ofs:
             ofs.write(template.render(**backend))
-    app.logger.info("Done.")
+    print("Done.")
 
 
 if __name__ == "__main__":

--- a/services/nginx/nginx.conf
+++ b/services/nginx/nginx.conf
@@ -19,12 +19,12 @@ http {
 
     access_log  /var/log/nginx/access.log  main;
 
-    sendfile        on;
+    # sendfile        on;
     #tcp_nopush     on;
 
     keepalive_timeout  65;
 
-    #gzip  on;
+    gzip  on;
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/api_gateway.conf;

--- a/services/nginx/turnpike-entrypoint.sh
+++ b/services/nginx/turnpike-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python3 /etc/nginx/build-backends.py $BACKENDS_CONFIG_MAP /etc/nginx/api_conf.d

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -3,10 +3,12 @@ FROM python:3.6
 WORKDIR /usr/src/app
 
 ENV FLASK_RUN_HOST 0.0.0.0
-RUN pip install --upgrade pip
-RUN apt-get update && apt-get install -y libxmlsec1 libxmlsec1-dev
+ENV BACKENDS_CONFIG_MAP=/etc/turnpike/backends.yml
+RUN pip install --no-cache-dir --upgrade pip && apt-get update && \
+    apt-get install -y libxmlsec1 libxmlsec1-dev --no-install-suggests --no-install-recommends && \
+    apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/*
 COPY ./requirements.txt /usr/src/app/requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app/
 CMD ["flask", "run"]

--- a/services/web/app.py
+++ b/services/web/app.py
@@ -158,7 +158,9 @@ class AuthView(views.MethodView):
                 self.backends[backend["route"]] = backend["auth"]
 
     def make_identity_header(self, identity_type, auth_type, auth_data):
-        header_data = dict(type=identity_type, auth_type=auth_type, **{identity_type.lower(): auth_data})
+        header_data = dict(
+            identity=dict(type=identity_type, auth_type=auth_type, **{identity_type.lower(): auth_data})
+        )
         app.logger.debug(header_data)
         return base64.encodebytes(json.dumps(header_data).encode("utf8")).replace(b"\n", b"")
 

--- a/services/web/app.py
+++ b/services/web/app.py
@@ -5,6 +5,7 @@ import os
 from urllib.parse import urlparse
 
 from flask import Flask, request, make_response, url_for, session, views, redirect
+from healthcheck import HealthCheck
 from werkzeug.middleware.proxy_fix import ProxyFix
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
@@ -194,6 +195,9 @@ app.add_url_rule("/saml/acs/", view_func=ACSView.as_view("saml-acs", app.config[
 app.add_url_rule("/saml/sls/", view_func=SLSView.as_view("saml-sls", app.config["SAML_PATH"]))
 app.add_url_rule("/auth/", view_func=AuthView.as_view("auth"))
 
+health = HealthCheck()
+
+app.add_url_rule("/_healthcheck/", view_func=health.run)
 
 #######################
 ### MOCKED SERVICES ###

--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -1,2 +1,3 @@
 flask
 python3-saml
+pyyaml

--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -1,3 +1,4 @@
 flask
 python3-saml
 pyyaml
+py-healthcheck==1.10.1


### PR DESCRIPTION
Using a config map mounted at `/etc/turnpike/backends.yml`, this change

* makes nginx generate a `location` stanza for each route, enabling auth as specified
* makes the Flask auth service consult the config map for what authorization rules to apply
* supports using docker-compose to simulate the config map