### PR TITLE
Pass identity header to services.

### DIFF
--- a/services/nginx/backend_template.conf.j2
+++ b/services/nginx/backend_template.conf.j2
@@ -2,6 +2,7 @@
         {% if auth %}
             auth_request     /auth/;
             auth_request_set $login_url $upstream_http_login_url;
+            auth_request_set $x_rh_identity $upstream_http_x_rh_identity;
         {% endif %}
         proxy_pass              {{ origin }};
         proxy_set_header        X-Original-URI $request_uri;
@@ -10,4 +11,5 @@
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header        X-Forwarded-Port 443;
         proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Rh-Identity $x_rh_identity;
     }

--- a/services/web/app.py
+++ b/services/web/app.py
@@ -2,6 +2,7 @@ import base64
 import contextlib
 import json
 import os
+import pprint
 from urllib.parse import urlparse
 
 from flask import Flask, request, make_response, url_for, session, views, redirect
@@ -214,4 +215,12 @@ app.add_url_rule("/_healthcheck/", view_func=health.run)
 #######################
 @app.route("/api/ping-service/ping")
 def ping():
-    return make_response("PONG!", 200)
+    response = "PONG!\n\n"
+    if request.headers.get("X-Rh-Identity"):
+        try:
+            response += pprint.pformat(json.loads(base64.decodebytes(request.headers["X-Rh-Identity"].encode("utf8"))))
+        except Exception as e:
+            response += f"(Error decoding identity header: {e})"
+    else:
+        response += "(No identity header found.)"
+    return make_response(response, 200)


### PR DESCRIPTION
While we generate the identity header from the auth service, we don't actually pass it along to the origin services. This fixes that. It also lets the ping service do some identity header debugging.