### PR TITLE
Make `/api/ping-service/ping` a more useful `/api/turnpike/identity` endpoint

### DIFF
--- a/dev-backends.yml
+++ b/dev-backends.yml
@@ -1,6 +1,6 @@
-- name: ping
-  route: /api/ping-service
-  origin: http://web:5000/api/ping-service
+- name: turnpike
+  route: /api/turnpike
+  origin: http://web:5000/api/turnpike
   auth:
     saml: "True"
 - name: healthcheck

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,9 +70,9 @@ to your `/etc/hosts` file a line:
 
     127.0.0.1  turnpike.example.com
 
-Then, go to https://turnpike.example.com/api/ping-service/ping in your browser. You should immediately be redirected to
-your configured IdP's login page, or if you're already logged into your IdP, a page that says "PONG" and outputs the
-content of your IdP's SAML assertion.
+Then, go to https://turnpike.example.com/api/turnpike/identity in your browser. You should immediately be redirected to
+your configured IdP's login page, or if you're already logged into your IdP, a page that outputs the content of your
+IdP's SAML assertion.
 
 Route Map and Attribute Based Access Control
 --------------------------------------------
@@ -81,9 +81,9 @@ Whether in Docker Compose or in Kubernetes/OpenShift, Turnpike expects that in t
 find its route map and access control list at `/etc/turnpike/backends.yml`. For Docker Compose, the file in your copy
 of Turnpike `dev-backends.yml` is mounted into the Flask container at this path:
 
-    - name: ping
-      route: /api/ping-service
-      origin: http://web:5000/api/ping-service
+    - name: turnpike
+      route: /api/turnpike
+      origin: http://web:5000/api/turnpike
       auth:
         saml: "True"
     - name: healthcheck

--- a/docs/userflow.puml
+++ b/docs/userflow.puml
@@ -8,7 +8,7 @@ participant Origin
 end box
 participant "Red Hat SSO" as rh_sso
 
-rh_associate -> Nginx: GET /api/ping-service/ping
+rh_associate -> Nginx: GET /api/turnpike/identity
 Nginx -> policy_service: GET /auth
 note left: Nginx asks the Policy Service to authn/authz
 policy_service -> Nginx: 401 Unauthorized
@@ -23,15 +23,15 @@ rh_associate -> rh_sso: Go through login flow
 rh_sso -> rh_associate: Redirect back to Turnpike w/ SAML Assertion
 rh_associate -> Nginx: GET /saml/acs w/ SAML Assertion
 Nginx -> policy_service: GET /saml/acs w/ SAML Assertion
-policy_service -> Nginx: Redirect to /api/ping-service/ping
+policy_service -> Nginx: Redirect to /api/turnpike/identity
 note right: Sets Session Cookie and stores SAML assertion data in Redis
-Nginx ->  rh_associate: Redirect to /api/ping-service/ping
-rh_associate -> Nginx: GET /api/ping-service/ping
+Nginx ->  rh_associate: Redirect to /api/turnpike/identity
+rh_associate -> Nginx: GET /api/turnpike/identity
 note left: Now with a valid session cookie
 Nginx -> policy_service: GET /auth
 policy_service -> Nginx: 200 OK
 note right: Valid session confirmed, X-Rh-Identity set
-Nginx -> Origin: /api/ping-service/ping
+Nginx -> Origin: /api/turnpike/identity
 note left: With X-Rh-Identity header
 Origin -> Nginx: 200 OK
 Nginx -> rh_associate: 200 OK

--- a/services/web/app.py
+++ b/services/web/app.py
@@ -214,17 +214,16 @@ health = HealthCheck()
 
 app.add_url_rule("/_healthcheck/", view_func=health.run)
 
-#######################
-### MOCKED SERVICES ###
-#######################
-@app.route("/api/ping-service/ping")
-def ping():
-    response = "PONG!\n\n"
+##################################
+### TURNPIKE SERVICE ENDPOINTS ###
+##################################
+@app.route("/api/turnpike/identity")
+def identity():
     if request.headers.get("X-Rh-Identity"):
         try:
-            response += pprint.pformat(json.loads(base64.decodebytes(request.headers["X-Rh-Identity"].encode("utf8"))))
+            response = json.loads(base64.decodebytes(request.headers["X-Rh-Identity"].encode("utf8")))
         except Exception as e:
-            response += f"(Error decoding identity header: {e})"
+            response = {"error": f"Error decoding identity header: {e}"}
     else:
-        response += "(No identity header found.)"
+        response = {"error": "No x-rh-identity header found in the request."}
     return make_response(response, 200)


### PR DESCRIPTION
Ahead of having some chroming in front of Turnpike, this sets up a way for the
front-end to grab identifying information from the SSO SAML assertion.

This will return the `x-rh-identity` header as JSON if it exists, otherwise returning
a JSON payload with an `error` message if it doesn't exist, or fails to parse.

- remove `/api/ping-service/ping` mocked service
- add `/api/turnpike/identity` utility endpoint
- updates docs to reflect this endpoint for consistency
- updates the backend config for this endpoint (will need to update config in app-interface)