### PR TITLE
Add mTLS (x509) authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 This is an internal gateway used to authenticate Red Hat associates against internal
-Red Hat SSO, along with an auth/policy service to handle SAML authentication and
+Red Hat SSO or mTLS, along with an auth/policy service to handle SAML authentication and
 provide ACL-based authorization.
 
 ## Setup and configuration

--- a/dev-backends.yml
+++ b/dev-backends.yml
@@ -3,6 +3,7 @@
   origin: http://web:5000/api/turnpike
   auth:
     saml: "True"
+    x509: "True"
 - name: healthcheck
   route: /_healthcheck
   origin: http://web:5000/_healthcheck

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,13 @@ services:
       NGINX_SSL_CONFIG: |
        ssl_certificate certs/cert.pem;
        ssl_certificate_key certs/key.pem;
+       ssl_verify_client optional;
+       ssl_verify_depth 3;
+       ssl_client_certificate certs/ca.pem;
+       if (${_dollarhack:-$}ssl_client_verify = "SUCCESS") {
+           set ${_dollarhack:-$}http_x_rh_certauth_cn /${_dollarhack:-$}ssl_client_s_dn;
+           set ${_dollarhack:-$}http_x_rh_certauth_issuer /${_dollarhack:-$}ssl_client_i_dn;
+       }
   redis:
     image: redis:6
     hostname: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
        ssl_verify_depth 3;
        ssl_client_certificate certs/ca.pem;
        if (${_dollarhack:-$}ssl_client_verify = "SUCCESS") {
-           set ${_dollarhack:-$}http_x_rh_certauth_cn /${_dollarhack:-$}ssl_client_s_dn;
+           set ${_dollarhack:-$}http_x_rh_certauth_subject /${_dollarhack:-$}ssl_client_s_dn;
            set ${_dollarhack:-$}http_x_rh_certauth_issuer /${_dollarhack:-$}ssl_client_i_dn;
        }
   redis:

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -4,6 +4,7 @@
 LAYOUT_LEFT_RIGHT
 
 Person(associate, "Red Hat Associate")
+System(service_account, "Service Account")
 
 System_Boundary(c_rh_c, "cloud.redhat.com"){
 
@@ -19,6 +20,7 @@ System_Boundary(c_rh_c, "cloud.redhat.com"){
 System_Ext(rhsso, "Red Hat Internal SSO")
 
 Rel(associate, nginx, "Uses", "HTTPS")
+Rel(service_account, nginx, "Uses", "mTLS")
 Rel(nginx, flask, "Delegates authz to", "HTTPS")
 Rel(associate, rhsso, "Authenticates", "HTTPS+SAML")
 Rel(flask, rhsso, "Validates assertion", "HTTPS+SAML")

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,9 +14,17 @@ data is stored in Redis to better manage content and expiry.
 
 ![Turnpike Architecture](turnpike-architecture.png)
 
-A successful service request workflow looks like:
+A successful SAML user request workflow looks like:
 
 ![Turnpike Userflow](turnpike-userflow.png)
+
+A successful mTLS request workflow looks like:
+
+![mTLS Flow](mtls.png)
+
+Note: TLS can be terminated either with Nginx itself, or with a standalone service in front of Nginx. The diagram's
+"mTLS Gateway" refers to whatever service terminates TLS. Also, the expected subject and issuer header names can be
+adjusted by setting `HEADER_CERTAUTH_SUBJECT` and `HEADER_CERTAUTH_ISSUER` variables.
 
 Nginx Configuration
 -------------------
@@ -134,7 +142,8 @@ For example to restrict the endpoint to a certificate with the DN of `/CN=test`,
 
     x509['subject_dn'] == '/CN=test'
 
-Note that CRL and/or OCSP support should be configured in `NGINX_SSL_CONFIG` as needed.
+If using TLS terminated at Nginx, note that CRL and/or OCSP support should be configured in `NGINX_SSL_CONFIG` as
+needed.
 
 Customizing and Extending Turnpike
 ----------------------------------

--- a/docs/mtls.puml
+++ b/docs/mtls.puml
@@ -1,0 +1,21 @@
+@startuml turnpike-mTLS
+
+participant "Service Account w/ x509 client cert" as service_account
+box "cloud.redhat.com"
+participant Nginx
+participant "Policy Service" as policy_service
+participant Origin
+end box
+
+service_account -> Nginx: GET /api/turnpike/identity
+note right: Nginx verifies client cert against configured TLS trust
+Nginx -> policy_service: GET /auth
+note left: Nginx asks the Policy Service to authz the cert's subject/issuer
+policy_service -> Nginx: 200 Authorized
+note right: Valid cert confirmed, X-Rh-Identity set
+Nginx -> Origin: /api/turnpike/identity
+note left: With X-Rh-Identity header
+Origin -> Nginx: 200 OK
+Nginx -> service_account: 200 OK
+
+@enduml

--- a/docs/mtls.puml
+++ b/docs/mtls.puml
@@ -2,17 +2,20 @@
 
 participant "Service Account w/ x509 client cert" as service_account
 box "cloud.redhat.com"
+participant "mTLS Gateway" as gateway
 participant Nginx
 participant "Policy Service" as policy_service
 participant Origin
 end box
 
-service_account -> Nginx: GET /api/turnpike/identity
-note right: Nginx verifies client cert against configured TLS trust
+service_account -> gateway: GET /api/turnpike/identity
+note right: Gateway verifies client cert
+gateway -> Nginx: GET /api/turnpike/identity
+note right: trusted cert confirmed, x-rh-certauth-{subject,issuer} set
 Nginx -> policy_service: GET /auth
 note left: Nginx asks the Policy Service to authz the cert's subject/issuer
 policy_service -> Nginx: 200 Authorized
-note right: Valid cert confirmed, X-Rh-Identity set
+note right: authorized cert confirmed, X-Rh-Identity set
 Nginx -> Origin: /api/turnpike/identity
 note left: With X-Rh-Identity header
 Origin -> Nginx: 200 OK

--- a/scripts/setup_devel_env
+++ b/scripts/setup_devel_env
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -e
+
+# add turnpike to the hosts file
+echo "Ensuring turnpike.example.com is in hosts file"
+grep -q turnpike.example.com /etc/hosts || sudo bash -c "echo '127.0.0.1 turnpike.example.com' >> /etc/hosts"
+
+# generate certs
+echo "Ensuring nginx is configured"
+test -d nginx/certs || mkdir nginx/certs
+test -f nginx/certs/ca.key || openssl genrsa -out nginx/certs/ca.key
+test -f nginx/certs/ca.csr || openssl req -new -key nginx/certs/ca.key -out nginx/certs/ca.csr -subj /CN=dev_ca/
+test -f nginx/certs/ca.pem || openssl x509 -req -days 720 -in nginx/certs/ca.csr -signkey nginx/certs/ca.key -out nginx/certs/ca.pem
+test -f nginx/certs/key.pem || openssl genrsa -out nginx/certs/key.pem
+test -f nginx/certs/cert.csr || openssl req -new -key nginx/certs/key.pem -out nginx/certs/cert.csr -subj /CN=turnpike.example.com/
+test -f nginx/certs/cert.pem || openssl x509 -req -days 720 -in nginx/certs/cert.csr -CA nginx/certs/ca.pem -CAkey nginx/certs/ca.key -CAcreateserial -out nginx/certs/cert.pem
+
+# install certs to auth service
+echo "Ensuring auth service is configured"
+test -f saml/settings.json || cat << EOF > saml/settings.json
+{
+    "strict": true,
+    "debug": true,
+    "sp": {
+        "entityId": "https://turnpike.example.com/saml/metadata.xml?$(uuidgen)",
+        "assertionConsumerService": {
+            "url": "https://turnpike.example.com/saml/acs/",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        },
+        "singleLogoutService": {
+            "url": "https://turnpike.example.com/saml/sls/",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        },
+        "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+    },
+    "idp": {
+        "entityId": "https://samltest.id/saml/idp",
+        "singleSignOnService": {
+            "url": "https://samltest.id/idp/profile/SAML2/Redirect/SSO",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        },
+        "x509cert": "MIIDEjCCAfqgAwIBAgIVAMECQ1tjghafm5OxWDh9hwZfxthWMA0GCSqGSIb3DQEB\nCwUAMBYxFDASBgNVBAMMC3NhbWx0ZXN0LmlkMB4XDTE4MDgyNDIxMTQwOVoXDTM4\nMDgyNDIxMTQwOVowFjEUMBIGA1UEAwwLc2FtbHRlc3QuaWQwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQC0Z4QX1NFKs71ufbQwoQoW7qkNAJRIANGA4iM0\nThYghul3pC+FwrGv37aTxWXfA1UG9njKbbDreiDAZKngCgyjxj0uJ4lArgkr4AOE\njj5zXA81uGHARfUBctvQcsZpBIxDOvUUImAl+3NqLgMGF2fktxMG7kX3GEVNc1kl\nbN3dfYsaw5dUrw25DheL9np7G/+28GwHPvLb4aptOiONbCaVvh9UMHEA9F7c0zfF\n/cL5fOpdVa54wTI0u12CsFKt78h6lEGG5jUs/qX9clZncJM7EFkN3imPPy+0HC8n\nspXiH/MZW8o2cqWRkrw3MzBZW3Ojk5nQj40V6NUbjb7kfejzAgMBAAGjVzBVMB0G\nA1UdDgQWBBQT6Y9J3Tw/hOGc8PNV7JEE4k2ZNTA0BgNVHREELTArggtzYW1sdGVz\ndC5pZIYcaHR0cHM6Ly9zYW1sdGVzdC5pZC9zYW1sL2lkcDANBgkqhkiG9w0BAQsF\nAAOCAQEASk3guKfTkVhEaIVvxEPNR2w3vWt3fwmwJCccW98XXLWgNbu3YaMb2RSn\n7Th4p3h+mfyk2don6au7Uyzc1Jd39RNv80TG5iQoxfCgphy1FYmmdaSfO8wvDtHT\nTNiLArAxOYtzfYbzb5QrNNH/gQEN8RJaEf/g/1GTw9x/103dSMK0RXtl+fRs2nbl\nD1JJKSQ3AdhxK/weP3aUPtLxVVJ9wMOQOfcy02l+hHMb6uAjsPOpOVKqi3M8XmcU\nZOpx4swtgGdeoSpeRyrtMvRwdcciNBp9UZome44qZAYH1iqrpmmjsfI9pJItsgWu\n3kXPjhSfj1AJGR1l9JGvJrHki1iHTA=="
+    }
+}
+EOF
+test -f saml/advanced_settings.json || cat << EOF > saml/advanced_settings.json
+{
+    "security": {
+        "nameIdEncrypted": false,
+        "authnRequestsSigned": false,
+        "logoutRequestSigned": false,
+        "logoutResponseSigned": false,
+        "signMetadata": false,
+        "wantMessagesSigned": false,
+        "wantAssertionsSigned": false,
+        "wantNameId" : true,
+        "wantNameIdEncrypted": false,
+        "wantAssertionsEncrypted": false,
+        "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+        "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256"
+    },
+    "contactPerson": {
+        "technical": {
+            "givenName": "technical_name",
+            "emailAddress": "technical@example.com"
+        },
+        "support": {
+            "givenName": "support_name",
+            "emailAddress": "support@example.com"
+        }
+    },
+    "organization": {
+        "en-US": {
+            "name": "sp_test",
+            "displayname": "SP test",
+            "url": "http://sp.example.com"
+        }
+    }
+}
+EOF

--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -26,7 +26,7 @@ PLUGIN_CHAIN = [
     "turnpike.plugins.rh_identity.RHIdentityPlugin",
 ]
 
-AUTH_PLUGIN_CHAIN = ["turnpike.plugins.saml.SAMLAuthPlugin"]
+AUTH_PLUGIN_CHAIN = ["turnpike.plugins.x509.X509AuthPlugin", "turnpike.plugins.saml.SAMLAuthPlugin"]
 
 DEFAULT_RESPONSE_CODE = 200
 

--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -20,6 +20,9 @@ PERMANENT_SESSION_LIFETIME = 60 * 60 * 4
 SESSION_COOKIE_SECURE = True
 MULTI_VALUE_SAML_ATTRS = os.environ.get("MULTI_VALUE_SAML_ATTRS", "").split(",")
 
+HEADER_CERTAUTH_SUBJECT = os.environ.get("HEADER_CERTAUTH_SUBJECT", "x-rh-certauth-subject")
+HEADER_CERTAUTH_ISSUER = os.environ.get("HEADER_CERTAUTH_ISSUER", "x-rh-certauth-issuer")
+
 PLUGIN_CHAIN = [
     "turnpike.plugins.auth.AuthPlugin",
     "turnpike.plugins.source_ip.SourceIPPlugin",

--- a/turnpike/plugins/x509.py
+++ b/turnpike/plugins/x509.py
@@ -1,0 +1,27 @@
+import logging
+from flask import request
+
+from ..plugin import TurnpikeAuthPlugin
+
+logger = logging.getLogger(__name__)
+
+
+class X509AuthPlugin(TurnpikeAuthPlugin):
+    name = "X509"
+    principal_type = "X509"
+    headers_needed = set(["x-rh-certauth-cn", "x-rh-certauth-issuer"])
+
+    def process(self, context, backend_auth):
+        logger.debug("Begin X509 plugin processing")
+        if "x509" in backend_auth and 'x-rh-certauth-cn' in request.headers:
+            auth_data = dict(
+                subject_dn = request.headers['x-rh-certauth-cn'],
+                issuer_dn = request.headers.get('x-rh-certauth-issuer'),
+            )
+            logger.debug(f"X509 auth_data: {auth_data}")
+            context.auth = dict(auth_data=auth_data, auth_plugin=self)
+            predicate = backend_auth["x509"]
+            authorized = eval(predicate, dict(x509=auth_data))
+            if not authorized:
+                context.status_code = 403
+        return context

--- a/turnpike/plugins/x509.py
+++ b/turnpike/plugins/x509.py
@@ -1,6 +1,7 @@
 import logging
 from flask import request
 
+from ..config import HEADER_CERTAUTH_SUBJECT, HEADER_CERTAUTH_ISSUER
 from ..plugin import TurnpikeAuthPlugin
 
 logger = logging.getLogger(__name__)
@@ -9,14 +10,14 @@ logger = logging.getLogger(__name__)
 class X509AuthPlugin(TurnpikeAuthPlugin):
     name = "X509"
     principal_type = "X509"
-    headers_needed = set(["x-rh-certauth-cn", "x-rh-certauth-issuer"])
+    headers_needed = set([HEADER_CERTAUTH_SUBJECT, HEADER_CERTAUTH_ISSUER])
 
     def process(self, context, backend_auth):
         logger.debug("Begin X509 plugin processing")
-        if "x509" in backend_auth and 'x-rh-certauth-cn' in request.headers:
+        if "x509" in backend_auth and HEADER_CERTAUTH_SUBJECT in request.headers:
             auth_data = dict(
-                subject_dn = request.headers['x-rh-certauth-cn'],
-                issuer_dn = request.headers.get('x-rh-certauth-issuer'),
+                subject_dn = request.headers[HEADER_CERTAUTH_SUBJECT],
+                issuer_dn = request.headers.get(HEADER_CERTAUTH_ISSUER),
             )
             logger.debug(f"X509 auth_data: {auth_data}")
             context.auth = dict(auth_data=auth_data, auth_plugin=self)

--- a/turnpike/plugins/x509.py
+++ b/turnpike/plugins/x509.py
@@ -1,23 +1,35 @@
 import logging
 from flask import request
 
-from ..config import HEADER_CERTAUTH_SUBJECT, HEADER_CERTAUTH_ISSUER
 from ..plugin import TurnpikeAuthPlugin
 
 logger = logging.getLogger(__name__)
 
 
 class X509AuthPlugin(TurnpikeAuthPlugin):
+    """
+    X509AuthPlugin performs authorization on headers that represent an X509
+    client certificate's identity. Subclasses may override the headers used
+    by setting the `subject_header` and `issuer_header` attributes.
+    """
     name = "X509"
     principal_type = "X509"
-    headers_needed = set([HEADER_CERTAUTH_SUBJECT, HEADER_CERTAUTH_ISSUER])
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.subject_header = self.app.config['HEADER_CERTAUTH_SUBJECT']
+        self.issuer_header = self.app.config['HEADER_CERTAUTH_ISSUER']
+
+    @property
+    def headers_needed(self):
+        return set([self.subject_header, self.issuer_header])
 
     def process(self, context, backend_auth):
         logger.debug("Begin X509 plugin processing")
-        if "x509" in backend_auth and HEADER_CERTAUTH_SUBJECT in request.headers:
+        if "x509" in backend_auth and self.subject_header in request.headers:
             auth_data = dict(
-                subject_dn = request.headers[HEADER_CERTAUTH_SUBJECT],
-                issuer_dn = request.headers.get(HEADER_CERTAUTH_ISSUER),
+                subject_dn = request.headers[self.subject_header],
+                issuer_dn = request.headers.get(self.issuer_header),
             )
             logger.debug(f"X509 auth_data: {auth_data}")
             context.auth = dict(auth_data=auth_data, auth_plugin=self)


### PR DESCRIPTION
Note: I added a script: `scripts/setup_devel_env` which generate certs and configuration if they don't exist. It may prove useful in trying to test this change. This script configures against samltest.id, and generates a unique SP entityId, so that turnpike developers don't overwrite each other's configs accidentally.

The approach I took was to go ahead and have nginx perform the authentication (verifying the client cert against a CA), and then pass the client cert subject and issuer to the turnpike service for authorization logic.

Also, note that I changed the auth order to try x509 first. The service falls back to SAML if the x509 header is not present. In this way, an endpoint can support either authentication method (SAML for humans, mTLS for services).

`x509` auth takes a Python expression which evaluates to `True` or `False`. It is passed a dictionary `x509` which contains two
attributes: `subject_dn` and `issuer_dn`, which can be used to further restrict which certs can be used (nginx already verifies the trust chain based on the configured CA file).

For example to restrict the endpoint to a certificate with the DN of `CN=test`, you could use `x509['subject_dn'] == 'CN=test'`.

Note that CRL and/or OCSP support should be configured in `NGINX_SSL_CONFIG` as needed.

To test, setup needed environment, start the services, and then execute

```
curl -k --cert services/nginx/certs/cert.pem --key services/nginx/certs/key.pem https://turnpike.example.com/api/turnpike/identity
```

and observe the resulting JSON document. Try a non-matching cert (any old cert will do), and verify that it receives 403.