### PR TITLE
Ensure `silent` defaults to `True` in `app.config.from_envvar`

### DIFF
--- a/turnpike/__init__.py
+++ b/turnpike/__init__.py
@@ -33,7 +33,7 @@ def create_app(test_config=None):
         app.config.from_mapping(test_config)
     else:
         app.config.from_object("turnpike.config")
-    app.config.from_envvar("TURNPIKE_CONFIG")
+    app.config.from_envvar("TURNPIKE_CONFIG", silent=True)
 
     session_obj = Session()
     session_obj.init_app(app)


### PR DESCRIPTION
This change ensures that if/when this file does not exist outside of a development
environment, the app will continue to boot.

Without this set, once deployed, Flask will fail to boot because the environment
variable `TURNPIKE_CONFIG` doesn't exist to point to a valid config file.

Reference: https://github.com/pallets/flask/blob/024f0d384cf5bb65c76ac59f8ddce464b2dc2ca1/src/flask/config.py#L89-L90