### PR TITLE
Use the auth data dictionary for the predicate eval

### DIFF
--- a/turnpike/plugins/saml.py
+++ b/turnpike/plugins/saml.py
@@ -140,14 +140,15 @@ class SAMLAuthPlugin(TurnpikeAuthPlugin):
     def process(self, context, backend_auth):
         current_app.logger.debug("Begin SAML Auth plugin processing")
         if "saml" in backend_auth and "samlUserdata" in session:
-            auth_data = session["samlUserdata"].items()
-            current_app.logger.debug(f"SAML auth_data: {auth_data}")
+            auth_dict = session["samlUserdata"]
+            auth_tuples = auth_dict.items()
+            current_app.logger.debug(f"SAML auth_data: {auth_tuples}")
             multi_value_attrs = self.app.config["MULTI_VALUE_SAML_ATTRS"]
             context.auth = dict(
-                auth_data={k: v if (len(v) > 1 or (k in multi_value_attrs)) else v[0] for k, v in auth_data}, 
+                auth_data={k: v if (len(v) > 1 or (k in multi_value_attrs)) else v[0] for k, v in auth_tuples},
                 auth_plugin=self)
             predicate = backend_auth["saml"]
-            authorized = eval(predicate, dict(user=auth_data))
+            authorized = eval(predicate, dict(user=auth_dict))
             if not authorized:
                 context.status_code = 403
         return context


### PR DESCRIPTION
Currently, the `auth_data` returned from `session["samlUserdata"].items()` is
a list of tuples, which means an authorization predicate to check against roles
in the SAML assertion would need to convert the object to a dictionary in order
to check for roles, something like:

```
auth:
  saml: "'Employee' in dict(user)['Role']"
```

This change, using `session["samlUserdata"]` directly in the eval globals would
make it so we can do something like:

```
auth:
  saml: "'Employee' in user['Role']"
```