### PR TITLE
Add PSK to x.509 handling and clean up templates

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -50,7 +50,7 @@ and what authentication/authorization requirements it should enforce. For exampl
       auth:
         saml: "True"
     - name: healthcheck
-      route: /_healthcheck
+      route: /public/healthcheck
       origin: http://web:5000/_healthcheck
 
 The map is a list of routes. Each route has three required fields: a `name` which must be a unique string, a `route`
@@ -180,26 +180,28 @@ would disable them automatically without a subsequent app-interface Merge Reques
 How to create a new Turnpike Route
 ----------------------------------
 
-The route map for Turnpike is managed in app-interface as a `ConfigMap`. To create or modify a route for the RHCSP
-Turnpike installation, you'll have to modify it and create a Merge Request.
+The route map for Turnpike is managed in app-interface as a deployment parameter that feeds
+into a `ConfigMap`. To create or modify a route for the RHCSP Turnpike installation, you'll
+have to modify it and create a Merge Request.
 
 1. Start with stage. In the app-interface tree, edit the file at:
-   `/resources/insights-stage/turnpike-stage/turnpike-stage-routes.configmap.yml`
+   `/data/services/insights/turnpike/namespaces/deploy.yml`
+   and add your route to the `BACKEND_ROUTES` parameter in the staging namespace.
 
 2. Make sure you allow Turnpike access to your service's namespace. Modify your namespace file, which if your app's
    name is `myapp` should be at `/data/services/insights/myapp/namespaces/stage-myapp-stage.yml`. Under the
    `networkPoliciesAllow` key, add to the list `$ref: /services/insights/turnpike/namespaces/stage-turnpike-stage.yml`
 
-3. Open a Merge Request. Please tag `@jginsber` or `@kwalsh` to double check your changes.
+3. Open a Merge Request. One of the Turnpike service owners will `/lgtm` your request.
 
 4. If the merge request works, you should be able to see your route in action at `internal.cloud.stage.redhat.com`
 
 5. If everything looks good, we can move to production. In the app-interface tree, edit the files as before at
-   `/resources/insights-prod/turnpike-prod/turnpike-prod-routes.configmap.yml` and
+   `/data/services/insights/turnpike/deploy.yml` and
    `/data/services/insights/myapp/namespaces/prod-myapp-prod.yml` (but don't forget to allow the `prod-turnpike-prod`
    namespace instead of the `stage-turnpike-stage` one.)
 
-6. Open a Merge Request. Please tag whomever double-checked your stage changes.
+6. Open a Merge Request. Again, a Turnpike service owner will `/lgtm` your request.
 
 If the merge request works, you should be able to see your route in action at `internal.cloud.redhat.com`.
 

--- a/templates/nginx.yml
+++ b/templates/nginx.yml
@@ -41,20 +41,11 @@ objects:
             - name: NGINX_LISTEN
               value: "${NGINX_LISTEN}"
             - name: NGINX_SERVER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: nginx-server-name
-                  name: turnpike-env
+              value: "${NGINX_SERVER_NAME}"
             - name: FLASK_SERVICE_URL
-              valueFrom:
-                configMapKeyRef:
-                  key: flask-service-url
-                  name: turnpike-env
+              value: "${FLASK_SERVICE_URL}"
             - name: FLASK_SERVER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: flask-server-name
-                  name: turnpike-env
+              value: "${FLASK_SERVER_NAME}"
             - name: NGINX_SSL_CONFIG
               value: "${NGINX_SSL_CONFIG}"
             - name: TURNPIKE_ALLOWED_ROUTES
@@ -71,7 +62,7 @@ objects:
               path: /_nginx/
               port: ${{NGINX_PORT}}
               scheme: ${NGINX_SCHEME}
-            initialDelaySeconds: 60
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 3
@@ -85,7 +76,7 @@ objects:
               path: /_nginx/
               port: ${{NGINX_PORT}}
               scheme: ${NGINX_SCHEME}
-            initialDelaySeconds: 40
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 3
@@ -157,4 +148,13 @@ parameters:
 - description: Domains allowed to be routed to
   name: ALLOWED_ORIGIN_DOMAINS
   value: '[".svc.cluster.local"]'
+  required: true
+- description: Effective hostname for this service
+  name: FLASK_SERVER_NAME
+  required: true
+- description: URL to Flask service
+  name: FLASK_SERVICE_URL
+  required: true
+- description: Nginx default server name
+  name: NGINX_SERVER_NAME
   required: true

--- a/templates/redis.yml
+++ b/templates/redis.yml
@@ -38,7 +38,26 @@ objects:
                 secretKeyRef:
                   key: redis-password
                   name: redis-password
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  key: redis-password
+                  name: redis-password
             image: registry.redhat.io/rhel8/redis-5:${IMAGE_TAG}
+            readinessProbe:
+              exec:
+                command: ['redis-cli', 'ping']
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 3
+            livenessProbe:
+              exec:
+                command: ['redis-cli', 'ping']
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 3
             imagePullPolicy: IfNotPresent
             name: redis
             ports:

--- a/templates/web.yml
+++ b/templates/web.yml
@@ -73,6 +73,13 @@ objects:
                   secretKeyRef:
                     key: redis-password
                     name: redis-password
+              - name: HEADER_CERTAUTH_PSK
+                value: ${HEADER_CERTAUTH_PSK}
+              - name: CDN_PRESHARED_KEY
+                valueFrom:
+                  secretKeyRef:
+                    key: akamai-psk
+                    name: psk
             image: quay.io/cloudservices/turnpike-web:${IMAGE_TAG}
             imagePullPolicy: Always
             name: web
@@ -132,3 +139,6 @@ parameters:
 - description: Image tag
   name: IMAGE_TAG
   required: true
+- description: Header that Akamai sends with the PSK
+  name: HEADER_CERTAUTH_PSK
+  value: "x-rh-insights-certauth-secret"

--- a/templates/web.yml
+++ b/templates/web.yml
@@ -41,11 +41,6 @@ objects:
       spec:
         containers:
           - env:
-              - name: FLASK_APP
-                valueFrom:
-                  configMapKeyRef:
-                    key: flask-app
-                    name: turnpike-env
               - name: PYTHONUNBUFFERED
                 value: "1"
               - name: SECRET_KEY
@@ -54,20 +49,11 @@ objects:
                     key: secret-key
                     name: secret-key
               - name: SERVER_NAME
-                valueFrom:
-                  configMapKeyRef:
-                    key: flask-server-name
-                    name: turnpike-env
+                value: "${FLASK_SERVER_NAME}"
               - name: FLASK_ENV
-                valueFrom:
-                  configMapKeyRef:
-                    key: flask-env
-                    name: turnpike-env
+                value: "${FLASK_ENV}"
               - name: REDIS_HOST
-                valueFrom:
-                  configMapKeyRef:
-                    key: redis-service-name
-                    name: turnpike-env
+                value: "${REDIS_SERVICE_NAME}"
               - name: REDIS_PASSWORD
                 valueFrom:
                   secretKeyRef:
@@ -78,15 +64,55 @@ objects:
               - name: CDN_PRESHARED_KEY
                 valueFrom:
                   secretKeyRef:
-                    key: akamai-psk
-                    name: psk
+                    key: gateway-secret
+                    name: apicast-insights-3scale-config
             image: quay.io/cloudservices/turnpike-web:${IMAGE_TAG}
             imagePullPolicy: Always
             name: web
             ports:
               - containerPort: 5000
                 protocol: TCP
-            resources: {}
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /_healthcheck/
+                port: 5000
+                scheme: "HTTP"
+                httpHeaders:
+                  - name: x-forwarded-host
+                    value: ${FLASK_SERVER_NAME}
+                  - name: x-forwarded-port
+                    value: '443'
+                  - name: x-forwarded-proto
+                    value: https
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 3
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /_healthcheck/
+                port: 5000
+                scheme: "HTTP"
+                httpHeaders:
+                  - name: x-forwarded-host
+                    value: ${FLASK_SERVER_NAME}
+                  - name: x-forwarded-port
+                    value: '443'
+                  - name: x-forwarded-proto
+                    value: https
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 3
+            resources:
+              limits:
+                cpu: ${CPU_LIMIT}
+                memory: ${MEMORY_LIMIT}
+              requests:
+                cpu: ${CPU_REQUEST}
+                memory: ${MEMORY_REQUEST}
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
             volumeMounts:
@@ -115,23 +141,45 @@ objects:
           - name: turnpike-saml-signing
             secret:
               secretName: saml-signing
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: turnpike
+    name: turnpike-routes
+  data:
+    backends.yml: |
+      ${BACKEND_ROUTES}
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: turnpike
+    name: turnpike-saml
+    annotations:
+      qontract.recycle: "true"
+  data:
+    settings.json: |
+      ${SETTINGS_JSON}
+    advanced_settings.json: |
+      ${ADVANCED_SETTINGS_JSON}
 parameters:
-- description: Initial amount of memory the Django container will request.
+- description: Initial amount of memory the Flask container will request.
   displayName: Memory Request
   name: MEMORY_REQUEST
   required: true
   value: 256Mi
-- description: Maximum amount of memory the Django container can use.
+- description: Maximum amount of memory the Flask container can use.
   displayName: Memory Limit
   name: MEMORY_LIMIT
   required: true
   value: 512Mi
-- description: Initial amount of cpu the Django container will request.
+- description: Initial amount of cpu the Flask container will request.
   displayName: CPU Request
   name: CPU_REQUEST
   required: true
   value: 200m
-- description: Maximum amount of cpu the Django container can use.
+- description: Maximum amount of cpu the Flask container can use.
   displayName: CPU Limit
   name: CPU_LIMIT
   required: true
@@ -142,3 +190,22 @@ parameters:
 - description: Header that Akamai sends with the PSK
   name: HEADER_CERTAUTH_PSK
   value: "x-rh-insights-certauth-secret"
+- description: Effective hostname for this service
+  name: FLASK_SERVER_NAME
+  required: true
+- description: Value for FLASK_ENV
+  name: FLASK_ENV
+  value: production
+  required: true
+- description: Service name for Redis
+  name: REDIS_SERVICE_NAME
+  required: true
+- description: OneLogin python3-saml settings.json content
+  name: SETTINGS_JSON
+  required: true
+- description: OneLogin python3-saml advanced_settings.json content
+  name: ADVANCED_SETTINGS_JSON
+  required: true
+- description: Backend route map
+  name: BACKEND_ROUTES
+  required: true

--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -3,6 +3,7 @@ import redis
 import yaml
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
+CDN_PRESHARED_KEY = os.environ.get("CDN_PRESHARED_KEY")
 
 if not SECRET_KEY:
     raise ValueError("No SECRET_KEY set.")
@@ -23,6 +24,7 @@ MULTI_VALUE_SAML_ATTRS = os.environ.get("MULTI_VALUE_SAML_ATTRS", "").split(",")
 
 HEADER_CERTAUTH_SUBJECT = os.environ.get("HEADER_CERTAUTH_SUBJECT", "x-rh-certauth-subject")
 HEADER_CERTAUTH_ISSUER = os.environ.get("HEADER_CERTAUTH_ISSUER", "x-rh-certauth-issuer")
+HEADER_CERTAUTH_PSK = os.environ.get("HEADER_CERTAUTH_PSK", None)
 
 PLUGIN_CHAIN = [
     "turnpike.plugins.auth.AuthPlugin",


### PR DESCRIPTION
The x.509 handling needs a PSK to be able to trust the headers when not forwarded by nginx itself.

Additionally, we need to rejigger the templates so that the ConfigMaps are parameterized, so they can be /lgtm'ed.

This does both.