### PR TITLE
Setup initial prometheus integration for nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 version: '3.7'
 
 services:
+  prometheus-nginx:
+    image: nginx/nginx-prometheus-exporter
+    depends_on:
+      - nginx
+    ports:
+    - 9113:9113
+    entrypoint:
+    - /usr/bin/exporter
+    - -nginx.scrape-uri
+    - http://172.17.0.1:8888/stub_status
   web:
     build: .
     ports:
@@ -24,6 +34,7 @@ services:
     build: ./nginx
     ports:
       - 443:8443
+      - 8888:8888
     depends_on:
       - web
     hostname: nginx

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,4 +29,5 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/api_gateway.conf;
+    include /etc/nginx/status.conf;
 }

--- a/nginx/status.conf
+++ b/nginx/status.conf
@@ -1,0 +1,7 @@
+server {
+  listen 8888;
+
+  location = /stub_status {
+    stub_status;
+  }
+}

--- a/templates/nginx.yml
+++ b/templates/nginx.yml
@@ -19,6 +19,10 @@ objects:
       port: 443
       protocol: TCP
       targetPort: ${{NGINX_PORT}}
+    - name: 8888-tcp
+      port: 8888
+      protocol: TCP
+      targetPort: 8888
     selector:
       name: nginx
 - apiVersion: apps/v1

--- a/templates/prometheus-nginx.yml
+++ b/templates/prometheus-nginx.yml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: turnpike
+  template: turnpike-prometheus-nginx
+metadata:
+  annotations:
+    description: Turnpike API gateway - prometheus nginx exporter setup
+  openshift.io/display-name: Turnpike Prometheus Nginx Exporter
+  name: turnpike
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: prometheus-nginx
+  spec:
+    ports:
+    - name: "9113"
+      port: 9113
+      targetPort: 9113
+    selector:
+      name: prometheus-nginx
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: prometheus-nginx
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        name: prometheus-nginx
+    template:
+      metadata:
+        labels:
+          name: prometheus-nginx
+        name: prometheus-nginx
+      spec:
+        containers:
+        - command:
+          - /usr/bin/exporter
+          - -nginx.scrape-uri
+          - http://nginx.svc.cluster.local:8888/stub_status
+          image: nginx/nginx-prometheus-exporter
+          imagePullPolicy: ""
+          name: prometheus-nginx
+          ports:
+          - containerPort: 9113
+          resources: {}
+        restartPolicy: Always
+        serviceAccountName: ""
+        volumes: null


### PR DESCRIPTION
This adds a new server for 8888, which the exporter will use to mount the /metrics
endpoint on port 9113: http://prometheus-nginx:9113/metrics

To test this locally:
  - run the images with docker-compose
  - verify the /stub_status endpoint: http://nginx:8888/stub_status
  - view metrics counts: http://prometheus-nginx:9113/metrics

Required changes in app-interface:
- requires a change to add port 8888 to the nginx service
- locally this should work with the config in the docker-compose file to connect
  to the nginx service, but in our template we'll need to update this to talk to
  the local nginx service in the namespace (http://nginx.svc.cluster.local:8888/stub_status)