### PR TITLE
Move off dockerhub image

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,6 +4,7 @@ set -exv
 
 NGINX_IMAGE="quay.io/cloudservices/turnpike-nginx"
 WEB_IMAGE="quay.io/cloudservices/turnpike-web"
+NGINX_PROMETHEUS_IMAGE="quay.io/cloudservices/turnpike-nginx-prometheus"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
@@ -17,6 +18,8 @@ docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
 docker --config="$DOCKER_CONF" build -t "${NGINX_IMAGE}:${IMAGE_TAG}" nginx
 docker --config="$DOCKER_CONF" build -t "${WEB_IMAGE}:${IMAGE_TAG}" .
+docker --config="$DOCKER_CONF" build -f ./nginx/Dockerfile-prometheus -t "${NGINX_PROMETHEUS_IMAGE}:${IMAGE_TAG}" .
 
 docker --config="$DOCKER_CONF" push "${NGINX_IMAGE}:${IMAGE_TAG}"
 docker --config="$DOCKER_CONF" push "${WEB_IMAGE}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF" push "${NGINX_PROMETHEUS_IMAGE}:${IMAGE_TAG}"

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -18,7 +18,10 @@ docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
 docker --config="$DOCKER_CONF" build -t "${NGINX_IMAGE}:${IMAGE_TAG}" nginx
 docker --config="$DOCKER_CONF" build -t "${WEB_IMAGE}:${IMAGE_TAG}" .
-docker --config="$DOCKER_CONF" build -f ./nginx/Dockerfile-prometheus -t "${NGINX_PROMETHEUS_IMAGE}:${IMAGE_TAG}" .
+docker --config="$DOCKER_CONF" build \
+       --build-arg scrapeuri=http://nginx:8888/stub_status \
+       -f ./nginx/Dockerfile-prometheus \
+       -t "${NGINX_PROMETHEUS_IMAGE}:${IMAGE_TAG}" .
 
 docker --config="$DOCKER_CONF" push "${NGINX_IMAGE}:${IMAGE_TAG}"
 docker --config="$DOCKER_CONF" push "${WEB_IMAGE}:${IMAGE_TAG}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,13 @@ version: '3.7'
 
 services:
   prometheus-nginx:
-    image: nginx/nginx-prometheus-exporter
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile-prometheus
     depends_on:
       - nginx
     ports:
     - 9113:9113
-    entrypoint:
-    - /usr/bin/exporter
-    - -nginx.scrape-uri
-    - http://172.17.0.1:8888/stub_status
   web:
     build: .
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ./nginx
       dockerfile: Dockerfile-prometheus
+      args:
+        scrapeuri: http://172.17.0.1:8888/stub_status
     depends_on:
       - nginx
     ports:

--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -1,8 +1,12 @@
 FROM quay.io/app-sre/centos:8
 
 USER root
+
+ARG scrapeuri
+ENV SCRAPE_URI $scrapeuri
+
 RUN dnf install -y git make go
 RUN git clone git://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
-CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri http://172.17.0.1:8888/stub_status
+CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri ${SCRAPE_URI}

--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/centos:8
+FROM registry.access.redhat.com/ubi8/ubi
 
 USER root
 

--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -1,0 +1,8 @@
+FROM quay.io/app-sre/centos:8
+
+USER root
+RUN dnf install -y git make go
+RUN git clone git://github.com/nginxinc/nginx-prometheus-exporter
+RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
+
+CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri http://172.17.0.1:8888/stub_status

--- a/templates/prometheus-nginx.yml
+++ b/templates/prometheus-nginx.yml
@@ -40,7 +40,7 @@ objects:
           - /usr/bin/exporter
           - -nginx.scrape-uri
           - http://nginx:8888/stub_status
-          image: nginx/nginx-prometheus-exporter
+          image: quay.io/cloudservices/turnpike-nginx-prometheus:${IMAGE_TAG}
           imagePullPolicy: ""
           name: prometheus-nginx
           ports:
@@ -49,3 +49,7 @@ objects:
         restartPolicy: Always
         serviceAccountName: ""
         volumes: null
+parameters:
+- description: Image tag
+  name: IMAGE_TAG
+  required: true

--- a/templates/prometheus-nginx.yml
+++ b/templates/prometheus-nginx.yml
@@ -39,7 +39,7 @@ objects:
         - command:
           - /usr/bin/exporter
           - -nginx.scrape-uri
-          - http://nginx.svc.cluster.local:8888/stub_status
+          - http://nginx:8888/stub_status
           image: nginx/nginx-prometheus-exporter
           imagePullPolicy: ""
           name: prometheus-nginx


### PR DESCRIPTION
This sets up a centos base image from Quay (based on the other base images we
use for NGINX in the project) and pulls in the exporter from GitHub, builds the
binary and runs it directly.