### PR TITLE
Temporarily remove prometheus-nginx port from nginx config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,6 @@
 version: '3.7'
 
 services:
-  prometheus-nginx:
-    build:
-      context: ./nginx
-      dockerfile: Dockerfile-prometheus
-      args:
-        scrapeuri: http://172.17.0.1:8888/stub_status
-    depends_on:
-      - nginx
-    ports:
-    - 9113:9113
   web:
     build: .
     ports:
@@ -34,7 +24,6 @@ services:
     build: ./nginx
     ports:
       - 443:8443
-      - 8888:8888
     depends_on:
       - web
     hostname: nginx

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,5 +29,4 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/api_gateway.conf;
-    include /etc/nginx/status.conf;
 }

--- a/nginx/status.conf
+++ b/nginx/status.conf
@@ -1,7 +1,0 @@
-server {
-  listen 8888;
-
-  location = /stub_status {
-    stub_status;
-  }
-}

--- a/templates/nginx.yml
+++ b/templates/nginx.yml
@@ -19,10 +19,6 @@ objects:
       port: 443
       protocol: TCP
       targetPort: ${{NGINX_PORT}}
-    - name: 8888-tcp
-      port: 8888
-      protocol: TCP
-      targetPort: 8888
     selector:
       name: nginx
 - apiVersion: apps/v1


### PR DESCRIPTION
This is causing a regression. We'll leave the `prometheus-nginx` config in place
and idle replicas for now.