### PR TITLE
Update the Turnpike base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/centos:8
+FROM quay.io/centos/centos:8
 
 WORKDIR /usr/src/app
 
@@ -6,7 +6,7 @@ ENV FLASK_RUN_HOST 0.0.0.0
 ENV BACKENDS_CONFIG_MAP=/etc/turnpike/backends.yml
 COPY ./Pipfile ./Pipfile.lock /usr/src/app/
 RUN dnf install -y dnf-plugins-core && \
-    dnf config-manager --set-enabled PowerTools && \
+    dnf config-manager --set-enabled powertools && \
     dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python36 python3-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
     pipenv lock --requirements > requirements.txt && \


### PR DESCRIPTION
quay.io/app-sre/centos:8 is no longer available. We have https://issues.redhat.com/browse/RHCLOUD-11345
logged to move to a RHEL-based UBI, but this thread: https://coreos.slack.com/archives/CCRND57FW/p1600357665112500
explains the challenges.

As an interim solution to unblock deployments, we'll be moving to the official
Centos mirror on Quay.

The `PowerTools` > `powertools` change is explained here:

- https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Yum_repo_file_and_repoid_changes
- https://bugs.centos.org/view.php?id=17920