### PR TITLE
Updating "turnpike-nginx" & "turnpike-web" Dockerfiles to use centos/centos:stream8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream8
 
 WORKDIR /usr/src/app
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream8
 
 # support running as an arbitrary user which belogs to the root group
 RUN dnf install -y nginx python3-jinja2 python3-yaml python36 && \


### PR DESCRIPTION
Updating "**turnpike-nginx**" & "**turnpike-web**" Dockerfiles to use "_centos:stream8_" instead of "_centos:8_" as security updates and backporting are better supported. Moreover, the primary reason for this change is to mitigate CVE-2021-33910 in a timely manner. 

**RPM Update (CESA-2021:2717):**
- Important CentOS systemd Update (CVE-2021-33910)
- 239-31.el8_2.2   -->   239-48.el8