### PR TITLE
Pin the version of nginx-prometheus-exporter

### DIFF
--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -6,7 +6,7 @@ ARG scrapeuri
 ENV SCRAPE_URI $scrapeuri
 
 RUN dnf install -y git make go
-RUN git clone git://github.com/nginxinc/nginx-prometheus-exporter
+RUN git clone git://github.com/nginxinc/nginx-prometheus-exporter --branch v0.8.0
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
 CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri ${SCRAPE_URI}


### PR DESCRIPTION
The latest version, 0.9.0 requires Golang 1.16 [1]. The latest Golang in the Red
Hat registry is currently 1.15.13-3, meaning we need to pin at the last working
version for our builds to succeed.

**Testing:**
Confirm the following build works:
```
docker build --build-arg scrapeuri=http://nginx:8888/stub_status -f ./nginx/Dockerfile-prometheus .
```

[1] https://github.com/nginxinc/nginx-prometheus-exporter/issues/193