### PR TITLE
Add internal /api/turnpike/session/ endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,18 @@ subsequent requests to use the stored session.
 
 This endpoint returns a 404 if `TESTING` is not enabled.
 
+## Retrieving your SAML session
+For SAML requests to your API outside of your browser via CURL for instance, you'll
+need to supply the `session` cookie like so:
+
+```
+curl https://internal.cloud.redhat.com/api/turnpike/identity/ -b 'session=<SESSION_COOKIE_STRING>'
+```
+
+You can either retrieve this from the browser developer tools by looking for the
+`session` cookie value, or by accessing `https://internal.cloud.redhat.com/api/turnpike/session/`
+in the browser, and getting the value from the `session` key.
+
 ## Linting/pre-commit
 Linting will run automatically with `black` in a pre-commit hook, but you'll need to run `pre-commit install` first.
 You can also run it manually with `pre-commit run -a`.
@@ -203,4 +215,3 @@ You can also run it manually with `pre-commit run -a`.
 [python3-saml]: https://github.com/onelogin/python3-saml
 [settings-example]: https://github.com/onelogin/python3-saml/blob/master/demo-flask/saml/settings.json
 [adv-settings-example]: https://github.com/onelogin/python3-saml/blob/master/demo-flask/saml/advanced_settings.json
-

--- a/turnpike/__init__.py
+++ b/turnpike/__init__.py
@@ -60,4 +60,5 @@ def create_app(test_config=None):
 
     app.add_url_rule("/auth/", view_func=views.policy_view)
     app.add_url_rule("/api/turnpike/identity/", view_func=views.identity)
+    app.add_url_rule("/api/turnpike/session/", view_func=views.session)
     return app

--- a/turnpike/views.py
+++ b/turnpike/views.py
@@ -58,3 +58,12 @@ def nginx_config_data():
         blueprints=[bp.url_prefix for bp in current_app.blueprints.values()],
     )
     return make_response(json.dumps(response_dict), 200, {"Content-Type": "application/json"})
+
+
+def session():
+    session_id = request.cookies.get("session")
+    if session_id:
+        response = {"session": session_id}
+    else:
+        response = {"error": "No session cookie found in the request."}
+    return make_response(response, 200)


### PR DESCRIPTION
In lieu of any current UI support, this will make it easier for teams to retrieve
their `session` cookie value for making any non-browser requests to their APIs.

The endpoint `https://internal.cloud.redhat.com/api/turnpike/session/` will now return a
payload structured as:

```
{
  "session": "<SESSION_COOKIE_STRING>"
}
```