### PR TITLE
Adds checks for saml and create it if does not exist

### DIFF
--- a/scripts/setup_devel_env
+++ b/scripts/setup_devel_env
@@ -17,6 +17,7 @@ test -f nginx/certs/cert.pem || openssl x509 -req -days 720 -in nginx/certs/cert
 
 # install certs to auth service
 echo "Ensuring auth service is configured"
+test -d saml || mkdir saml
 test -f saml/settings.json || cat << EOF > saml/settings.json
 {
     "strict": true,


### PR DESCRIPTION
On a fresh clone of turnpike, `saml` folder does not exist.
This creates the folder in that case.