### PR TITLE
Updating the build_deploy.sh to use Podman

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -14,7 +14,6 @@ fi
 
 AUTH_CONF_DIR="$(pwd)/.podman"
 mkdir -p $AUTH_CONF_DIR
-export REGISTRY_AUTH_FILE="$AUTH_CONF_DIR/auth.json"
 
 podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 


### PR DESCRIPTION
### Updating the `build_deploy.sh` to use Podman

- `Podman` is now being used within the script as opposed to `Docker`.
   - This is due to the migration of the Jenkins build job to a RHEL8 node.
   - The Jenkins build job has migrated to a RHEL8 node to support the UBI8 build of Turnpike-Web.