### PR TITLE
Updating the Turnpike Web YAML to use the new Elasticache Service

### DIFF
--- a/templates/web.yml
+++ b/templates/web.yml
@@ -55,12 +55,10 @@ objects:
               - name: FLASK_ENV
                 value: "${FLASK_ENV}"
               - name: REDIS_HOST
-                value: "${REDIS_SERVICE_NAME}"
-              - name: REDIS_PASSWORD
                 valueFrom:
                   secretKeyRef:
-                    key: redis-password
-                    name: redis-password
+                    key: db.endpoint
+                    name: in-memory-db
               - name: HEADER_CERTAUTH_PSK
                 value: ${HEADER_CERTAUTH_PSK}
               - name: CDN_PRESHARED_KEY


### PR DESCRIPTION
#### JIRA TICKET: https://issues.redhat.com/browse/RHCLOUD-16755
---
Updating the Turnpike Web YAML to use the new Elasticache Service as opposed to Redis.

Reference to new Elasticache Service:
- https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/28731/diffs