### PR TITLE
Updating the Turnpike Templates to support the "REPLICAS" parameter

### DIFF
--- a/templates/nginx.yml
+++ b/templates/nginx.yml
@@ -26,7 +26,7 @@ objects:
   metadata:
     name: nginx
   spec:
-    replicas: 1
+    replicas: ${{REPLICAS}}
     selector:
       matchLabels:
         name: nginx
@@ -158,3 +158,6 @@ parameters:
 - description: Nginx default server name
   name: NGINX_SERVER_NAME
   required: true
+- description: Replica count for turnpike-nginx
+  name: REPLICAS
+  value: "1"

--- a/templates/redis.yml
+++ b/templates/redis.yml
@@ -17,7 +17,7 @@ objects:
       template: turnpike-redis
     name: redis
   spec:
-    replicas: 1
+    replicas: ${{REPLICAS}}
     selector:
       matchLabels:
         name: redis
@@ -135,3 +135,6 @@ parameters:
 - description: Image tag
   name: IMAGE_TAG
   required: true
+- description: Replica count for turnpike-redis
+  name: REPLICAS
+  value: "1"

--- a/templates/web.yml
+++ b/templates/web.yml
@@ -32,7 +32,7 @@ objects:
       service: web
     name: web
   spec:
-    replicas: 1
+    replicas: ${{REPLICAS}}
     selector:
       matchLabels:
         name: web
@@ -216,3 +216,6 @@ parameters:
 - description: Debug authentication backends
   name: AUTH_DEBUG
   value: ""
+- description: Replica count for turnpike-web
+  name: REPLICAS
+  value: "1"


### PR DESCRIPTION
#### JIRA TICKET: https://issues.redhat.com/browse/RHCLOUD-16755
---
Updating the `Web`, `Nginx`, and `Redis` Templates to support the "REPLICAS" parameter. This change is to support the spin-down of the Turnpike FedRAMP Production environment.