### PR TITLE
Pushing the new containerized PR_CHECK

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .vscode/
 saml/
 nginx/
+!nginx/build_config.py
 docs/
 templates/
 scripts/

--- a/Dockerfile-pr-check
+++ b/Dockerfile-pr-check
@@ -15,4 +15,4 @@ RUN dnf install -y dnf-plugins-core && \
 
 COPY . /usr/src/app/
 
-CMD [".pr_tests/pr_tests.sh"]
+CMD ["./pr_tests/pr_tests.sh"]

--- a/Dockerfile-pr-check
+++ b/Dockerfile-pr-check
@@ -1,0 +1,18 @@
+FROM quay.io/centos/centos:stream8
+
+WORKDIR /usr/src/app
+
+
+COPY ./Pipfile ./Pipfile.lock /usr/src/app/
+
+RUN dnf install -y dnf-plugins-core && \
+    # Enabling "Powertools" to provide the same libraries and developer tools to CentOS image as RH "CodeReady Builder" does for RHEL
+    dnf config-manager --set-enabled powertools && \
+    dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python36 python3-devel libxml2-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl && \
+    pip3 install --no-cache-dir --upgrade pip pipenv && \
+    pipenv lock --requirements > requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app/
+
+CMD [".pr_tests/pr_tests.sh"]

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -14,7 +14,7 @@ trap "teardown_podman" EXIT SIGINT SIGTERM
 set -ex
 
 # Setup environment for pre-commit check
-pip install black pre-commit
+pip3 install black pre-commit
 
 # Run pre-commit
 if ! (pre-commit run -a); then

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,10 +1,45 @@
 #!/bin/bash
 
-set -exv
+export CONTAINER_NAME="turnpike-pr-check"
+export IMAGE_TAG="turnpike:pr-check"
 
-python3 -m venv .
-source bin/activate
-bin/pip3 install --upgrade pip pipenv
-bin/pipenv install -d
-bin/pre-commit run -a
-bin/pytest
+function teardown_podman() {
+    podman rm -f $CONTAINER_NAME || true
+    podman image rm -f $IMAGE_TAG || true
+}
+
+# Catches process termination and cleans up Podman artifacts
+trap "teardown_podman" EXIT SIGINT SIGTERM
+
+set -ex
+
+# Setup environment for pre-commit check
+pip install black pre-commit
+
+# Run pre-commit
+if ! (pre-commit run -a); then
+    echo "pre-commit ecountered an issue"
+    exit 1
+fi
+
+# Build PR_CHECK Image
+podman build --no-cache -f Dockerfile-pr-check --tag $IMAGE_TAG
+
+# Build PR_Check Container
+podman create --name $CONTAINER_NAME $IMAGE_TAG
+
+# Run PR_CHECK Container (attached with standard output)
+# and reports if the Containerized PR_Check fails
+if ! (podman start -a $CONTAINER_NAME); then
+    echo "Test failure observed; aborting"
+    exit 1
+fi
+
+# Pass Jenkins dummy artifacts as it needs
+# an xml output to consider the job a success.
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -14,7 +14,9 @@ trap "teardown_podman" EXIT SIGINT SIGTERM
 set -ex
 
 # Setup environment for pre-commit check
-pip3 install black pre-commit
+python3 -m venv .
+source bin/activate
+bin/pip3 install black pre-commit
 
 # Run pre-commit
 if ! (pre-commit run -a); then

--- a/pr_tests/pr_tests.sh
+++ b/pr_tests/pr_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+pip install --upgrade pip pipenv
+pipenv install -d
+pipenv run pytest --disable-pytest-warnings tests/
+result=$?
+
+if [ $result -ne 0 ]; then
+    echo '====================================='
+    echo '====  ✖  ERROR: PR_CHECK FAILED  ===='
+    echo '====================================='
+    exit 1
+fi


### PR DESCRIPTION
#### Jira Ticket: https://issues.redhat.com/browse/RHCLOUD-18559
-----
#### What Changed:
- `nginx/build_config.py` was added as an exception within the `.dockerignore` file as it is needed to carry out the pytests.
- `Dockerfile-pr-check` was create to map out the containerized version of turnpike's pr checks.
- `pr_tests.sh` was create to instruct the PR CHECK container on how to carry out the pytests.
- `pr_check.sh` was rebuilt from the ground up to handle the Jenkins creation, running, teardown, and clean up of the containerized PR CHECK.

#### Local Testing:
- ✅   `CentOS-Based` PR CHECK image was successfully built and ran locally _(Within RHEL8 environment)_
