### PR TITLE
Updating Dockerfile-prometheus

### DIFF
--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -6,7 +6,7 @@ ARG scrapeuri
 ENV SCRAPE_URI $scrapeuri
 
 RUN microdnf install -y git make go
-RUN git clone git://github.com/nginxinc/nginx-prometheus-exporter --branch v0.8.0
+RUN git clone https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
 CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri ${SCRAPE_URI}


### PR DESCRIPTION
#### Jira Ticket: https://issues.redhat.com/browse/RHCLOUD-18559
-----
#### What Changed:
- Updated the protocol for the `git clone` command within `Dockerfile-prometheus`.
   - Was `git://` now `https://`
   - This change is because the unauthenticated git protocol on port 9418 is no longer supported. [1]

- Additionally, the `--branch v0.8.0` tag was removed from the `git clone` command, as UBI8 now supports `Go v1.16`.


#### Local Testing:
- ✅   `UBI8-Based` Turnpike Prometheus image successfully built locally.

#### References:
[1] https://github.blog/2021-09-01-improving-git-protocol-security-github/

