### PR TITLE
Updating Dockerfile to support Python38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN microdnf install -y dnf && \
     dnf install -y dnf-plugins-core && \
     # Enabling RH "CodeReady Builder" to provide the same libraries and developer tools to the UBI image as "Powertools" does for CentOS.
     dnf config-manager --set-enable codeready-builder-for-rhel-8-x86_64-rpms && \
-    dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python38 python3-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python38-devel && \
+    dnf install -y gcc xmlsec1 xmlsec1-devel python38-pip python38 libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python38-devel && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
     pipenv lock --requirements > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt && \


### PR DESCRIPTION
#### Jira Ticket: https://issues.redhat.com/browse/RHCLOUD-19198
-----
#### What Changed:
The `Dockerfile` for `Turnpike-Web` has been updated to support the installation of Python38 and removed Python36 dependencies.

RPMs changes via `dnf` Command:
- `python3-pip` -> `python38-pip`
- Removed `python3-devel`


#### Local Testing:
- ✅   `RHEL8-Based` image successfully built locally (within a RHEL8 VM)

