### PR TITLE
Pin the version of nginx-prometheus-exporter

### DIFF
--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -6,7 +6,7 @@ ARG scrapeuri
 ENV SCRAPE_URI $scrapeuri
 
 RUN microdnf install -y git make go
-RUN git clone https://github.com/nginxinc/nginx-prometheus-exporter
+RUN git clone --branch v0.10.0 https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
 CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri ${SCRAPE_URI}


### PR DESCRIPTION
Similar change as https://github.com/RedHatInsights/turnpike/pull/54

The latest version requires Golang 1.18. The latest Golang in the Red
Hat registry is currently 1.17, meaning we need to pin at the last working
version for our builds to succeed.