### PR TITLE
Remove null volume template reference

### DIFF
--- a/templates/prometheus-nginx.yml
+++ b/templates/prometheus-nginx.yml
@@ -44,7 +44,6 @@ objects:
           resources: {}
         restartPolicy: Always
         serviceAccountName: ""
-        volumes: null
         imagePullSecrets:
         - name: quay-cloudservices-pull
         - name: rh-registry-pull


### PR DESCRIPTION
Resolves an issue where app-interface MR checks don't handle null values. Their fix is here: https://github.com/app-sre/qontract-reconcile/pull/2626