### PR TITLE
Fix `pipenv lock --requirements`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN microdnf install -y dnf && \
     dnf config-manager --set-enable codeready-builder-for-rhel-8-x86_64-rpms && \
     dnf install -y gcc xmlsec1 xmlsec1-devel python38-pip python38 libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python38-devel && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
-    pipenv lock --requirements > requirements.txt && \
+    pipenv requirements > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt && \
     dnf remove -y gcc python3-devel && \
     rm -rf /var/lib/dnf /var/cache/dnf

--- a/Dockerfile-env
+++ b/Dockerfile-env
@@ -10,7 +10,7 @@ RUN dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled powertools && \
     dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python38 python3-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python38-devel && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
-    pipenv lock --requirements > requirements.txt && \
+    pipenv requirements > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt && \
     dnf remove -y gcc python3-devel && \
     rm -rf /var/lib/dnf /var/cache/dnf

--- a/Dockerfile-pr-check
+++ b/Dockerfile-pr-check
@@ -10,7 +10,7 @@ RUN dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled powertools && \
     dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python38 python3-devel libxml2-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python38-devel && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
-    pipenv lock --requirements > requirements.txt && \
+    pipenv requirements > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app/


### PR DESCRIPTION
This option is now deprecated, and is replaced by using `pipenv requirements`:
https://github.com/pypa/pipenv/releases/tag/v2022.8.13