### PR TITLE
Use dynamic resolver from /etc/resolv.conf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ SECRET_KEY=
 FLASK_ENV=development
 MULTI_VALUE_SAML_ATTRS=Role
 AUTH_DEBUG=1
+TURNPIKE_ALLOWED_ORIGIN_DOMAINS=web,echo-server,foo,host.docker.internal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.8
 repos:
 - repo: https://github.com/psf/black
-  rev: 19.3b0
+  rev: 22.3.0
   hooks:
   - id: black
     args: ["-l", "119", "-t", "py38"]

--- a/dev-backends.yml
+++ b/dev-backends.yml
@@ -4,6 +4,12 @@
   auth:
     saml: "True"
     x509: "True"
+- name: rbac
+  route: /api/rbac
+  origin: http://host.docker.internal:8000/_private/api
+  auth:
+    saml: "True"
+    x509: "True"
 - name: healthcheck
   route: /public/healthcheck/
   origin: http://web.svc.cluster.local:5000/_healthcheck/
@@ -19,3 +25,6 @@
   origin: http://echo-server.svc.cluster.local:8080/
   source_ip:
     - 240.0.0.0/4
+- name: nginx_regression_test
+  route: /api/does_not_exist/
+  origin: http://foo:5000/does_not_exist/

--- a/nginx/backend_template.conf.j2
+++ b/nginx/backend_template.conf.j2
@@ -6,7 +6,7 @@
         {% for header in headers %}
         auth_request_set $turnpike_{{ header.lower().replace("-", "_") }} $upstream_http_{{ header.lower().replace("-", "_") }};
         {% endfor %}
-        proxy_pass              $upstream$1;
+        proxy_pass              $upstream$1$is_args$args;
         proxy_set_header        X-Original-URI $request_uri;
         proxy_set_header        X-Real-IP $remote_addr;
         proxy_set_header        X-Forwarded-Host $proxy_host;

--- a/nginx/backend_template.conf.j2
+++ b/nginx/backend_template.conf.j2
@@ -1,10 +1,12 @@
-    location {{ route }} {
+    location ~ {{ route }}(.*)$ {
+        resolver {{ resolver }} valid=30s;
+        set $upstream  {{ origin }};
         auth_request     /auth/;
         auth_request_set $login_url $upstream_http_login_url;
         {% for header in headers %}
         auth_request_set $turnpike_{{ header.lower().replace("-", "_") }} $upstream_http_{{ header.lower().replace("-", "_") }};
         {% endfor %}
-        proxy_pass              {{ origin }};
+        proxy_pass              $upstream$1;
         proxy_set_header        X-Original-URI $request_uri;
         proxy_set_header        X-Real-IP $remote_addr;
         proxy_set_header        X-Forwarded-Host $proxy_host;

--- a/nginx/backend_template.conf.j2
+++ b/nginx/backend_template.conf.j2
@@ -1,5 +1,5 @@
     location ~ {{ route }}(.*)$ {
-        resolver {{ resolver }};
+        resolver {{ resolver }} valid=60s;
         set $upstream  {{ origin }};
         auth_request     /auth/;
         auth_request_set $login_url $upstream_http_login_url;

--- a/nginx/backend_template.conf.j2
+++ b/nginx/backend_template.conf.j2
@@ -1,5 +1,5 @@
     location ~ {{ route }}(.*)$ {
-        resolver {{ resolver }} valid=30s;
+        resolver {{ resolver }};
         set $upstream  {{ origin }};
         auth_request     /auth/;
         auth_request_set $login_url $upstream_http_login_url;

--- a/nginx/build_config.py
+++ b/nginx/build_config.py
@@ -49,12 +49,13 @@ def validate_route(backend):
 
 
 def get_resolver():
-    file = open("/etc/resolv.conf", "r")
+    resolver_file_name = "/etc/resolv.conf"
+    file = open(resolver_file_name, "r")
     match = re.search("(?<=nameserver )(.*)(?=\\n)", file.read())
-    if match:
-        resolver = match.group()
-    else:
-        resolver = "127.0.0.11"
+    if not match:
+        raise Exception(f"Error getting resolver from {resolver_file_name}")
+
+    resolver = match.group()
     print(f"Using resolver: {resolver}")
     return resolver
 

--- a/nginx/build_config.py
+++ b/nginx/build_config.py
@@ -56,6 +56,7 @@ def get_resolver():
     else:
         resolver = "127.0.0.11"
     print(f"Using resolver: {resolver}")
+    return resolver
 
 
 def main(args):

--- a/nginx/build_config.py
+++ b/nginx/build_config.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+import re
 import time
 from urllib import parse, request, error
 import warnings
@@ -47,6 +48,16 @@ def validate_route(backend):
     return True
 
 
+def get_resolver():
+    file = open("/etc/resolv.conf", "r")
+    match = re.search("(?<=nameserver )(.*)(?=\\n)", file.read())
+    if match:
+        resolver = match.group()
+    else:
+        resolver = "127.0.0.11"
+    print(f"Using resolver: {resolver}")
+
+
 def main(args):
     try:
         with open(args.config_map_path) as ifs:
@@ -77,6 +88,7 @@ def main(args):
     headers_to_upstream = nginx_config["to_upstream"]
     headers_to_policy_service = nginx_config["to_policy_service"]
     blueprints = nginx_config["blueprints"]
+    resolver = get_resolver()
 
     with open("/etc/nginx/api_gateway.conf.j2") as ifs:
         template = jinja2.Template(ifs.read())
@@ -90,7 +102,7 @@ def main(args):
         print(f"Processing backend configuration for {name}")
         if validate_route(backend):
             with open(f"/etc/nginx/api_conf.d/{name}.conf", "w") as ofs:
-                ofs.write(template.render(headers=headers_to_upstream, **backend))
+                ofs.write(template.render(headers=headers_to_upstream, resolver=resolver, **backend))
     print("Done.")
 
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,7 +4,7 @@ export CONTAINER_NAME="turnpike-pr-check"
 export IMAGE_TAG="turnpike:pr-check"
 export NGINX_IMAGE="quay.io/cloudservices/turnpike-nginx"
 export WEB_IMAGE="quay.io/cloudservices/turnpike-web"
-export PR_IMAGE_TAG=PR-$(git rev-parse --short=7 HEAD)
+export PR_IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
 function teardown_podman() {
     podman rm -f $CONTAINER_NAME || true

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -32,7 +32,6 @@ podman build --no-cache -f Dockerfile-pr-check --tag $IMAGE_TAG
 
 # Build PR_Check Container
 podman create --name $CONTAINER_NAME $IMAGE_TAG
-podman push "${IMAGE_TAG}:${IMAGE_TAG}"
 
 # Build a PR image to deploy
 podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -2,9 +2,6 @@
 
 export CONTAINER_NAME="turnpike-pr-check"
 export IMAGE_TAG="turnpike:pr-check"
-export NGINX_IMAGE="quay.io/cloudservices/turnpike-nginx"
-export WEB_IMAGE="quay.io/cloudservices/turnpike-web"
-export PR_IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
 function teardown_podman() {
     podman rm -f $CONTAINER_NAME || true
@@ -32,15 +29,6 @@ podman build --no-cache -f Dockerfile-pr-check --tag $IMAGE_TAG
 
 # Build PR_Check Container
 podman create --name $CONTAINER_NAME $IMAGE_TAG
-
-# Build a PR image to deploy
-podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-
-podman build -t "${NGINX_IMAGE}:${PR_IMAGE_TAG}" nginx
-podman push "${NGINX_IMAGE}:${PR_IMAGE_TAG}"
-
-podman build -t "${WEB_IMAGE}:${PR_IMAGE_TAG}" .
-podman push "${WEB_IMAGE}:${PR_IMAGE_TAG}"
 
 # Run PR_CHECK Container (attached with standard output)
 # and reports if the Containerized PR_Check fails


### PR DESCRIPTION
Follow-up to the work in https://github.com/RedHatInsights/turnpike/pull/81
--
Jira: https://issues.redhat.com/browse/RHCLOUD-11173

When the NGINX server starts, and one or more upstream hosts can't be resolved,
NGINX fails to come online at all. This means pods will enter a crash loop, and
Turnpike will be down in the given environment.

To fix the issue, we need to ensure NGINX doesn't try to resolve all hosts at start,
and setting the proxy_pass value to a variable will lazily resolve the host.

The following changes work locally, and have been deployed and tested in stage.

- Configure a local regression API which will cause NGINX to fail to start if it
doesn't resolve without this fix in place.
- Update the location matcher so that we can explicitly proxy the entire request
path, which doesn't happen when you use a variable in the config.
- Use the `/etc/resolv.conf` nameserver IP value for the NGINX resolver.
- Set the `$upstream` to proxy to, in a variable so that resolution doesn't happen
at startup. This will allow for other services to be online, while the failing
service(s) will throw a 5xx until the resolver picks up the changes, assuming
it comes back online.
