### PR TITLE
Updating pre-commit-config and adding requirements.txt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: debug-statements
+- repo: https://github.com/casey-williams-rh/pipenv-pre-commit
+  rev: v1.1.0
+  hooks:
+  - id: pipenv-generate-requirements

--- a/Dockerfile-pr-check
+++ b/Dockerfile-pr-check
@@ -11,7 +11,7 @@ RUN dnf install -y dnf-plugins-core && \
     dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python38 python3-devel libxml2-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python38-devel && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
     pipenv requirements > requirements.txt && \
-    pip3 install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app/
 

--- a/Dockerfile-pr-check
+++ b/Dockerfile-pr-check
@@ -11,7 +11,7 @@ RUN dnf install -y dnf-plugins-core && \
     dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python38 python3-devel libxml2-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python38-devel && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
     pipenv requirements > requirements.txt && \
-    pip install --no-cache-dir -r requirements.txt
+    pip3 install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app/
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -14,6 +14,7 @@ trap "teardown_podman" EXIT SIGINT SIGTERM
 set -ex
 
 # Setup environment for pre-commit check
+dnf list installed
 python3 -m venv .
 source bin/activate
 bin/pip3 install pipenv

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -14,7 +14,7 @@ trap "teardown_podman" EXIT SIGINT SIGTERM
 set -ex
 
 # Setup environment for pre-commit check
-python38 -m venv .
+python3.8 -m venv .
 source bin/activate
 bin/pip3 install pipenv
 bin/pip3 install black pre-commit

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -16,6 +16,7 @@ set -ex
 # Setup environment for pre-commit check
 python3 -m venv .
 source bin/activate
+bin/pip3 install pipenv
 bin/pip3 install black pre-commit
 
 # Run pre-commit

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -14,8 +14,7 @@ trap "teardown_podman" EXIT SIGINT SIGTERM
 set -ex
 
 # Setup environment for pre-commit check
-dnf list installed
-python3 -m venv .
+python38 -m venv .
 source bin/activate
 bin/pip3 install pipenv
 bin/pip3 install black pre-commit

--- a/pr_tests/pr_tests.sh
+++ b/pr_tests/pr_tests.sh
@@ -3,6 +3,7 @@
 set -ex
 
 pip install --upgrade pip pipenv
+pipenv lock --clear
 pipenv install -d
 pipenv run pytest --disable-pytest-warnings tests/
 result=$?

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,24 @@
+-i https://pypi.org/simple
+async-timeout==4.0.2 ; python_version >= '3.6'
+cachelib==0.6.0 ; python_version >= '3.6'
+click==7.1.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+deprecated==1.2.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+flask==1.1.4
+flask-session==0.3.2
+gunicorn==20.1.0
+isodate==0.6.1
+itsdangerous==1.1.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+jinja2==2.11.3
+lxml==4.6.5 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+markupsafe==2.0.1
+packaging==21.3 ; python_version >= '3.6'
+prometheus-client==0.14.1
+py-healthcheck==1.10.1
+pyparsing==3.0.8 ; python_full_version >= '3.6.8'
+python3-saml==1.14.0
+pyyaml==6.0
+redis==4.2.2
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+werkzeug==1.0.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+wrapt==1.14.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+xmlsec==1.3.12 ; python_version >= '3.5'


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-21373

## Description of Intent of Change(s)

### Change 1:
The security scanner, Snyk, requires the `requirements.txt` for Python-based vulnerability scanning. At this time, this repo uses Pipenv, which only generates a "Pipfile" and a Pipfile.lock".

This MR add `requirements.txt` to the repo. Additionally, the `.pre-commit-config.yaml` file has been update to use the following:

- **[pipenv-pre-commit](https://github.com/casey-williams-rh/pipenv-pre-commit)**
   - Anytime a `Pipfile.lock` is committed this hook will generate an updated requirements.txt file.

### Change 2:
`pr_check.sh` has been updated to specify the use of `Python 3.8` as opposed to the default `Python 3.6`. This change is due to `Python 3.6` not properly executing `pipenv`.

### Change 3:
`pr_tests/pr_tests.sh` has been updated to clear the `pipenv` cache. The `pipenv` lock sequence caches results to speed up subsequent runs. The cache may contain faulty results if a bug causes the format to corrupt, even after the bug is fixed. `--clear` flushes the cache, and therefore removes the bad results. Additionally, this can also be a pain if, for some reason, python tries to grab the `Built Distribution` over the `Source Distribution`

