### PR TITLE
[RHCLOUD-16254] upgrade nginx version in turnpike-nginx image

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.access.redhat.com/ubi8-minimal
 
-# support running as an arbitrary user which belogs to the root group
-RUN microdnf install -y nginx python38-jinja2 python38-yaml python38 && \
+# support running as an arbitrary user which belongs to the root group
+RUN microdnf module enable nginx:1.20 && \
+    microdnf install -y nginx python38-jinja2 python38-yaml python38 && \
     chmod g+rwx /var/log/nginx && \
     rm -rf /var/lib/dnf /var/cache/dnf
 


### PR DESCRIPTION
[RHCLOUD-16254: Multiple Vulnerabilities in Turnpike nginx](https://issues.redhat.com/browse/RHCLOUD-16254)

nginx upgrade to the version 1:1.20.1-1.module+el8.6.0+13722+f063ea60



