### PR TITLE
exception for turnpike for DVO min 3 replicas

### DIFF
--- a/templates/nginx.yml
+++ b/templates/nginx.yml
@@ -25,6 +25,8 @@ objects:
   kind: Deployment
   metadata:
     name: nginx
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "for turnpike-nginx we dont need 3 replicas"
   spec:
     replicas: ${{REPLICAS}}
     selector:

--- a/templates/web.yml
+++ b/templates/web.yml
@@ -31,6 +31,8 @@ objects:
     labels:
       service: web
     name: web
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "for turnpike-web we dont need 3 replicas"
   spec:
     replicas: ${{REPLICAS}}
     selector:


### PR DESCRIPTION
this PR adds exception for turnpike and DVO minimal three replicas check

- [RHCLOUD-19507](https://issues.redhat.com/browse/RHCLOUD-19507) [FIRING:2] deployment_validation_operator_minimum_three_replicas turnpike crcs02ue1 deployment-validation-operator-metrics deployment-validation-operator
- [RHCLOUD-19587](https://issues.redhat.com/browse/RHCLOUD-19587) [FIRING:2] deployment_validation_operator_minimum_three_replicas turnpike crcp01ue1 deployment-validation-operator-metrics deployment-validation-operator