### PR TITLE
deploy nginx prometheus

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -24,7 +24,6 @@ podman build -t "${WEB_IMAGE}:${IMAGE_TAG}" .
 podman push "${WEB_IMAGE}:${IMAGE_TAG}"
 
 podman build \
-       --build-arg scrapeuri=http://nginx:8888/stub_status \
        -f ./nginx/Dockerfile-prometheus \
        -t "${NGINX_PROMETHEUS_IMAGE}:${IMAGE_TAG}" .
 podman push "${NGINX_PROMETHEUS_IMAGE}:${IMAGE_TAG}"

--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -2,11 +2,10 @@ FROM registry.access.redhat.com/ubi8-minimal
 
 USER root
 
-ARG scrapeuri
-ENV SCRAPE_URI $scrapeuri
+ENV SCRAPE_URI=http://localhost:8080/stub_status
 
 RUN microdnf install -y git make go
 RUN git clone --branch v0.10.0 https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
-CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri ${SCRAPE_URI}
+CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri $SCRAPE_URI

--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -5,7 +5,7 @@ USER root
 ENV SCRAPE_URI=http://localhost:8080/stub_status
 
 RUN microdnf install -y git make go
-RUN git clone --branch v0.10.0 https://github.com/nginxinc/nginx-prometheus-exporter
+RUN git clone --branch v0.11.0 https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
 CMD ["./nginx-prometheus-exporter/nginx-prometheus-exporter", "-nginx.scrape-uri", "$SCRAPE_URI"]

--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -8,4 +8,4 @@ RUN microdnf install -y git make go
 RUN git clone --branch v0.10.0 https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
-CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri $SCRAPE_URI
+CMD ["./nginx-prometheus-exporter/nginx-prometheus-exporter", "-nginx.scrape-uri", "$SCRAPE_URI"]

--- a/nginx/api_gateway.conf.j2
+++ b/nginx/api_gateway.conf.j2
@@ -16,6 +16,10 @@ server {
         return 200 "OK";
     }
 
+    location = /stub_status {
+        stub_status;
+    }
+
     location = /auth/ {
         internal;
 

--- a/templates/prometheus-nginx.yml
+++ b/templates/prometheus-nginx.yml
@@ -50,6 +50,13 @@ objects:
         imagePullSecrets:
         - name: quay-cloudservices-pull
         - name: rh-registry-pull
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT}
+            memory: ${MEMORY_LIMIT}
+          requests:
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
 parameters:
 - description: Image tag
   name: IMAGE_TAG
@@ -60,3 +67,23 @@ parameters:
 - description: URI nginx is running on so prometheus knows where to scrape metrics
   name: NGINX_SCRAPE_URI
   required: true
+- description: Initial amount of memory the prometheus-nginx container will request.
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  required: true
+  value: 256Mi
+- description: Maximum amount of memory the prometheus-nginx container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- description: Initial amount of cpu the prometheus-nginx container will request.
+  displayName: CPU Request
+  name: CPU_REQUEST
+  required: true
+  value: 50m
+- description: Maximum amount of cpu the prometheus-nginx container can use.
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  required: true
+  value: 200m

--- a/templates/prometheus-nginx.yml
+++ b/templates/prometheus-nginx.yml
@@ -36,8 +36,11 @@ objects:
         name: prometheus-nginx
       spec:
         containers:
+        - env:
+          - name: SCRAPE_URI
+            value: ${NGINX_SCRAPE_URI}
         - image: quay.io/cloudservices/turnpike-nginx-prometheus:${IMAGE_TAG}
-          imagePullPolicy: ""
+          imagePullPolicy: "IfNotPresent"
           name: prometheus-nginx
           ports:
           - containerPort: 9113
@@ -54,3 +57,6 @@ parameters:
 - description: Replica count for prometheus-nginx
   name: REPLICAS
   value: "1"
+- description: URI nginx is running on so prometheus knows where to scrape metrics
+  name: NGINX_SCRAPE_URI
+  required: true


### PR DESCRIPTION
## Summary
* updated the way nginx prometheus is built & deployed so we can set the scrape uri on deployment per env

### Changes
* update the nginx prometheus dockerfile to use an environment variable to set `scrape_uri`, which points the nginx metrics exporter to the instance of nginx running
* add a parameter to the deployment template so we can set this variable per env
* remove build arg in build_deploy to not overwrite the env variable

~~## DO NOT MERGE
Must set the new required param `NGINX_SCRAPE_URI` in app interface first. I will update this when done
https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/84811~~
edit: done