### PR TITLE
nginx and nginx-prometheus images upgrade

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.access.redhat.com/ubi8-minimal
 
 # support running as an arbitrary user which belongs to the root group
 RUN microdnf module enable nginx:1.22 && \
-    microdnf install -y nginx python38-jinja2 python38-yaml python38 && \
+    microdnf install -y nginx python3.11 python3.11-pip && \
+    pip3 install --no-cache-dir jinja2 pyyaml && \
     chmod g+rwx /var/log/nginx && \
     rm -rf /var/lib/dnf /var/cache/dnf
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8-minimal
 
 # support running as an arbitrary user which belongs to the root group
-RUN microdnf module enable nginx:1.20 && \
+RUN microdnf module enable nginx:1.22 && \
     microdnf install -y nginx python38-jinja2 python38-yaml python38 && \
     chmod g+rwx /var/log/nginx && \
     rm -rf /var/lib/dnf /var/cache/dnf


### PR DESCRIPTION
**turnpike-nginx image:**
- enabled nginx:1.22 module
- use python3.11 module and fix vulnerabilities found by Grype tool
```
NAME        INSTALLED  FIXED-IN  TYPE    VULNERABILITY        SEVERITY 
pip         20.2.4     21.1      python  GHSA-5xp3-jfq3-5q8x  Medium    
setuptools  50.3.2     65.5.1    python  GHSA-r9hx-vwmv-q579  High   
```