### PR TITLE
update nginx prometheus dockerfile cmd

### DIFF
--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -8,4 +8,4 @@ RUN microdnf install -y git make go
 RUN git clone --branch v0.11.0 https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
-CMD ["./nginx-prometheus-exporter/nginx-prometheus-exporter", "-nginx.scrape-uri", "$SCRAPE_URI"]
+CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri $SCRAPE_URI


### PR DESCRIPTION
update cmd in nginx dockerfile to run with shell so we can use env var

To test:
```
podman build -f ./nginx/Dockerfile-prometheus .
podman run -e SCRAPE_URI=http://localhost:8080/stub_status <image tag>

NGINX Prometheus Exporter version=0.11.0 commit=e4a6810d4f0b776f7fde37fea1d84e4c7284b72a date=2022-09-07T21:09:51Z, dirty=false, arch=linux/amd64, go=go1.19.13
2023/11/01 19:51:26 Starting...
2023/11/01 19:51:26 Could not create Nginx Client: failed to get http://localhost:8080/stub_status: Get "http://localhost:8080/stub_status": dial tcp [::1]:8080: connect: connection refused
```
that confirms the env var is read (im not actually running nginx locally so thats why connection refused but thats fine for this testing), vs right now if you build and run master the same way you will see this:
```
NGINX Prometheus Exporter version=0.11.0 commit=e4a6810d4f0b776f7fde37fea1d84e4c7284b72a date=2022-09-07T21:09:51Z, dirty=false, arch=linux/amd64, go=go1.19.13
2023/11/01 19:51:15 Starting...
2023/11/01 19:51:15 Could not create Nginx Client: failed to get $SCRAPE_URI: Get "$SCRAPE_URI": unsupported protocol scheme ""
```
which means the default value of the env var was overridden as expected but it was not actually read in the CMD, cuz its shown as empty