### PR TITLE
[RHCLOUD-32214] use git-core in Dockerfile for turnpike-prometheus-nginx

### DIFF
--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -4,7 +4,7 @@ USER root
 
 ENV SCRAPE_URI=http://localhost:8080/stub_status
 
-RUN microdnf install -y git make go
+RUN microdnf install -y git-core make go
 RUN git clone --branch v0.11.0 https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 


### PR DESCRIPTION
JIRA: [RHCLOUD-32214](https://issues.redhat.com/browse/RHCLOUD-32214)

use `git-core` instead of `git` package -> we need this only for clone the nginx-prometheus-exporter