### PR TITLE
[RHCLOUD-32389] Dockerfile for turnpike-web image update - remove the redundant package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN microdnf install -y dnf && \
     dnf install -y dnf-plugins-core && \
     # Enabling RH "CodeReady Builder" to provide the same libraries and developer tools to the UBI image as "Powertools" does for CentOS.
     dnf config-manager --set-enable codeready-builder-for-rhel-8-x86_64-rpms && \
-    dnf install -y gcc xmlsec1 xmlsec1-devel python39-pip python39 libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python39-devel && \
+    dnf install -y gcc xmlsec1 xmlsec1-devel python39 libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python39-devel && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
     pipenv requirements > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt && \

--- a/Dockerfile-pr-check
+++ b/Dockerfile-pr-check
@@ -8,7 +8,7 @@ COPY ./Pipfile ./Pipfile.lock /usr/src/app/
 RUN dnf install -y dnf-plugins-core && \
     # Enabling "Powertools" to provide the same libraries and developer tools to CentOS image as RH "CodeReady Builder" does for RHEL
     dnf config-manager --set-enabled powertools && \
-    dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python39 python3-devel libxml2-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python39-devel && \
+    dnf install -y gcc xmlsec1 xmlsec1-devel python39 python3-devel libxml2-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python39-devel && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
     pipenv install --dev
 


### PR DESCRIPTION
JIRA [RHCLOUD-32389](https://issues.redhat.com/browse/RHCLOUD-32389)

this is result from `python39` nad `python39-pip` install and both packages are installing same dependencies so I believe we can simplify our Dockerfile for `turnpike-web` image

```
dnf install -y python39
(1/6): python39-3.9.18-1.module+el8.9.0+20024+793d7211.aarch64.rpm
(2/6): python39-pip-wheel-20.2.4-8.module+el8.9.0+21344+82807453.1.noarch.rpm
(3/6): python39-pip-20.2.4-8.module+el8.9.0+21344+82807453.1.noarch.rpm
(4/6): python39-setuptools-wheel-50.3.2-4.module+el8.9.0+19644+d68f775d.noarch.rpm
(5/6): python39-setuptools-50.3.2-4.module+el8.9.0+19644+d68f775d.noarch.rpm
(6/6): python39-libs-3.9.18-1.module+el8.9.0+20024+793d7211.aarch64.rpm

dnf install -y python39-pip
(1/6): python39-3.9.18-1.module+el8.9.0+20024+793d7211.aarch64.rpm
(2/6): python39-pip-20.2.4-8.module+el8.9.0+21344+82807453.1.noarch.rpm
(3/6): python39-setuptools-50.3.2-4.module+el8.9.0+19644+d68f775d.noarch.rpm
(4/6): python39-pip-wheel-20.2.4-8.module+el8.9.0+21344+82807453.1.noarch.rpm
(5/6): python39-setuptools-wheel-50.3.2-4.module+el8.9.0+19644+d68f775d.noarch.rpm
(6/6): python39-libs-3.9.18-1.module+el8.9.0+20024+793d7211.aarch64.rpm
```