### PR TITLE
[RHCLOUD-32389] Dockerfile-env for local development update

### DIFF
--- a/Dockerfile-env
+++ b/Dockerfile-env
@@ -3,16 +3,15 @@ FROM quay.io/centos/centos:stream8
 WORKDIR /usr/src/app
 
 ENV FLASK_RUN_HOST 0.0.0.0
+
 ENV BACKENDS_CONFIG_MAP=/etc/turnpike/backends.yml
-COPY ./Pipfile ./Pipfile.lock /usr/src/app/
-RUN dnf install -y dnf-plugins-core && \
-    # Enabling "Powertools" to provide the same libraries and developer tools to CentOS image as RH "CodeReady Builder" does for RHEL
-    dnf config-manager --set-enabled powertools && \
-    dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python39 python3-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python39-devel && \
-    pip3 install --no-cache-dir --upgrade pip pipenv && \
-    pipenv requirements > requirements.txt && \
-    pip install --no-cache-dir -r requirements.txt && \
-    dnf remove -y gcc python3-devel && \
-    rm -rf /var/lib/dnf /var/cache/dnf
+
+COPY ./pip.conf /etc
 COPY . /usr/src/app/
+
+RUN dnf install --enablerepo=powertools -y python39-pip python39-devel gcc xmlsec1 xmlsec1-devel xmlsec1-openssl xmlsec1-openssl-devel openssl libtool-ltdl-devel && \
+    pip3.9 install --no-cache-dir -r requirements.txt && \
+    dnf remove -y python3.9-devel gcc xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel && \
+    rm -rf /var/lib/dnf /var/cache/dnf
+
 CMD ["./run-server.sh"]

--- a/pip.conf
+++ b/pip.conf
@@ -1,0 +1,2 @@
+[global]
+trusted-host = pypi.org files.pythonhosted.org


### PR DESCRIPTION
JIRA [RHCLOUD-32389](https://issues.redhat.com/browse/RHCLOUD-32389)

the `Dockerfile-env` is used for local build for `turnpike-web` but right know its failing with
```
Collecting async-timeout==4.0.2
  Downloading async_timeout-4.0.2-py3-none-any.whl (5.8 kB)
ERROR: Could not find a version that satisfies the requirement blinker==1.7.0 (from versions: 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5)
ERROR: No matching distribution found for blinker==1.7.0
Error: building at STEP "RUN dnf install -y dnf-plugins-core &&     dnf config-manager --set-enabled powertools &&     dnf install -y gcc xmlsec1 xmlsec1-devel python3-pip python39 python3-devel libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python39-devel &&     pip3 install --no-cache-dir --upgrade pip pipenv &&     pipenv requirements > requirements.txt &&     pip install --no-cache-dir -r requirements.txt &&     dnf remove -y gcc python3-devel &&     rm -rf /var/lib/dnf /var/cache/dnf": while running runtime: exit status 1
```

with my fix the image is built successfully
and I added the `pip.conf` file that solves the SSL issue related with pip installation

thank you @frenzymadness for help