### PR TITLE
remove python39-devel from the turnpike-web Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN microdnf install -y dnf && \
     pip3 install --no-cache-dir --upgrade pip pipenv && \
     pipenv requirements > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt && \
-    dnf remove -y gcc python3-devel && \
+    dnf remove -y gcc python39-devel && \
     rm -rf /var/lib/dnf /var/cache/dnf
 COPY . /usr/src/app/
 CMD ["./run-server.sh"]


### PR DESCRIPTION
the removing the `python3-devel` package doesnt have an effect because this package is not present in the container
```
# dnf remove -y python3-devel
No match for argument: python3-devel
No packages marked for removal.
Dependencies resolved.
Nothing to do.
```

but we can remove the python39-devel package ... I believe this was an intention but with all the python upgrades we forgot to update this line too