### PR TITLE
[RHCLOUD-32986] Dockerfile for turnpike-web image update - use only pip to install dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,15 @@ ENV FLASK_RUN_HOST 0.0.0.0
 
 ENV BACKENDS_CONFIG_MAP=/etc/turnpike/backends.yml
 
-COPY ./Pipfile ./Pipfile.lock /usr/src/app/
+COPY ./requirements.txt /usr/src/app/
 
 RUN microdnf install -y dnf && \
     dnf install -y dnf-plugins-core && \
     # Enabling RH "CodeReady Builder" to provide the same libraries and developer tools to the UBI image as "Powertools" does for CentOS.
     dnf config-manager --set-enable codeready-builder-for-rhel-8-x86_64-rpms && \
     dnf install -y gcc xmlsec1 xmlsec1-devel python39 libtool-ltdl-devel xmlsec1-openssl xmlsec1-openssl-devel openssl python39-devel && \
-    pip3 install --no-cache-dir --upgrade pip pipenv && \
-    pipenv requirements > requirements.txt && \
-    pip install --no-cache-dir -r requirements.txt && \
+    pip3 install --no-cache-dir --upgrade pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
     dnf remove -y gcc python39-devel xmlsec1-devel libtool-ltdl-devel xmlsec1-openssl-devel && \
     rm -rf /var/lib/dnf /var/cache/dnf
 


### PR DESCRIPTION
right now we use the `pipenv` to create `requirements.txt` file and then we install dependencies from this file with `pip`
but
we already have `requirements.txt` file in the repo so we don't need to install `pipenv` and use it only for this file generation