### PR TITLE
[RHCLOUD-33805] bump nginx-prometheus-exporter to the latest version

### DIFF
--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -5,7 +5,7 @@ USER root
 ENV SCRAPE_URI=http://localhost:8080/stub_status
 
 RUN microdnf install -y git-core make go
-RUN git clone --branch v0.11.0 https://github.com/nginxinc/nginx-prometheus-exporter
+RUN git clone --branch v1.2.0 https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
 CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri $SCRAPE_URI


### PR DESCRIPTION
[RHCLOUD-33805](https://issues.redhat.com/browse/RHCLOUD-33805)

https://github.com/nginxinc/nginx-prometheus-exporter 