### PR TITLE
used new flag format for parametr in Dockerfile for turnpike-prometheus-nginx

### DIFF
--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -8,4 +8,4 @@ RUN microdnf install -y git-core make go
 RUN git clone --branch v1.2.0 https://github.com/nginxinc/nginx-prometheus-exporter
 RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
 
-CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter -nginx.scrape-uri $SCRAPE_URI
+CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter --nginx.scrape-uri $SCRAPE_URI


### PR DESCRIPTION
I found the deprecation warning in logs for the prometheus-nginx pod (turnpike) in OpenShift 
https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com/k8s/ns/turnpike-prod/pods/prometheus-nginx-644cc685f4-whnz6/logs
`the flag format is deprecated and will be removed in a future release, please use the new format: --nginx.scrape-uri`