### PR TITLE
[RHCLOUD-36900] add pre-commit github action into repo

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,24 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+
+    - name: Install Pipenv
+      run: pip install pipenv
+
+    - name: Run Pre-Commit
+      uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3
 repos:
 - repo: https://github.com/psf/black
-  rev: 24.8.0
+  rev: 24.10.0
   hooks:
   - id: black
     args: ["-l", "119", "-t", "py39"]

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -13,17 +13,6 @@ trap "teardown_podman" EXIT SIGINT SIGTERM
 
 set -ex
 
-# Setup environment for pre-commit check
-python3 -m venv venv
-source venv/bin/activate
-pip3 install pipenv
-pip3 install pre-commit
-# Run pre-commit
-if ! (pre-commit run -av); then
-    echo "pre-commit ecountered an issue"
-    exit 1
-fi
-
 # Build PR_CHECK Image
 podman build --no-cache -f Dockerfile-pr-check --tag $IMAGE_TAG
 


### PR DESCRIPTION
[RHCLOUD-36900](https://issues.redhat.com/browse/RHCLOUD-36900) 

moved pre-commit check in own github action
and
update `black` to the latest version in pre-commit config

---

motivation: in previous version the pre-commit check runs via Jenkins worker with python 3.8 and that was not align with python 3.9 we use in the project, additionally it was not possible to use latest `black` version (requires python >= 3.9)

moving into own github action we can better distinguish between pre-commit checks and rest pr check defined in the `pr_check.sh`