### PR TITLE
[RHCLOUD-32031] use temp directory for podman config

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -12,7 +12,19 @@ if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     exit 1
 fi
 
-AUTH_CONF_DIR="$(pwd)/.podman"
+# Create tmp dir to store data in during job run (do NOT store in $WORKSPACE)
+export TMP_JOB_DIR=$(mktemp -d -p "$HOME" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
+echo "job tmp dir location: $TMP_JOB_DIR"
+
+function job_cleanup() {
+    echo "cleaning up job tmp dir: $TMP_JOB_DIR"
+    rm -fr $TMP_JOB_DIR
+}
+
+trap job_cleanup EXIT ERR SIGINT SIGTERM
+
+AUTH_CONF_DIR="$TMP_JOB_DIR/.podman"
+
 mkdir -p $AUTH_CONF_DIR
 
 podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io


### PR DESCRIPTION
[RHCLOUD-32031](https://issues.redhat.com/browse/RHCLOUD-32031)

according step 1 in [Credential Leak Self Assessment document ](https://docs.google.com/document/d/1IsX7NmMnWPcuOseyjjUj_T9VjBXx7p3UjWs5eNpDHyI/edit?tab=t.0) use temp directory for podman config