### PR TITLE
[RHCLOUD-32031]  update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 .git/
+.github/
+.pytest_cache/
+.tekton/
 .vscode/
 saml/
 nginx/
@@ -6,6 +9,10 @@ nginx/
 docs/
 templates/
 scripts/
-Dockerfile
+docker-compose.yml
+Dockerfile*
 .dockerignore
 .env
+.podman
+.docker
+.kube

--- a/nginx/.dockerignore
+++ b/nginx/.dockerignore
@@ -1,3 +1,6 @@
-Dockerfile
+Dockerfile*
 .dockerignore
 certs/
+.podman
+.docker
+.kube


### PR DESCRIPTION
[RHCLOUD-32031](https://issues.redhat.com/browse/RHCLOUD-32031)

one of recommendations in [Credential Leak Self Assessment](https://docs.google.com/document/d/1IsX7NmMnWPcuOseyjjUj_T9VjBXx7p3UjWs5eNpDHyI/edit?tab=t.0) document is to add `.dockerignore` file into repository