### PR TITLE
[KONFLUX] Fix nginx-pull request

### DIFF
--- a/.tekton/turnpike-nginx-pull-request.yaml
+++ b/.tekton/turnpike-nginx-pull-request.yaml
@@ -7,9 +7,8 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master" && ( "nginx/***".pathChanged() || ".tekton/turnpike-nginx-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: turnpike


### PR DESCRIPTION
Right now the nginx-pull request pipeline is not appearing during checks, and the annotation for the nginx is different from the rest of the other pipelines, so fixing it to be the same 