### PR TITLE
[RHCLOUD-37573] specify the base image version in dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile-env
+++ b/Dockerfile-env
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile-pr-check
+++ b/Dockerfile-pr-check
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 WORKDIR /usr/src/app
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 # support running as an arbitrary user which belongs to the root group
 RUN microdnf module enable nginx:1.22 && \

--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 USER root
 


### PR DESCRIPTION
[RHCLOUD-37573](https://issues.redhat.com/browse/RHCLOUD-37573)

base image ubi8/ubi-minimal in the RH catalog: https://catalog.redhat.com/software/containers/ubi8-minimal/5c64772edd19c77a158ea216?container-tabs=overview

this change will enable the Konflux Bot to automatically detect when a new base image version is released and create a PR for the update and we will have better control over the base image version