### PR TITLE
[RHCLOUD-38790] enable new version of nginx in Dockerfile

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741599792
 
 # support running as an arbitrary user which belongs to the root group
-RUN microdnf module enable -y nginx:1.22 && \
+RUN microdnf module enable -y nginx:1.24 && \
     microdnf install -y nginx python3.11 pip && \
     pip3 install --no-cache-dir jinja2 pyyaml && \
     chmod g+rwx /var/log/nginx && \


### PR DESCRIPTION
[RHCLOUD-38790](https://issues.redhat.com/browse/RHCLOUD-38790)