### PR TITLE
add type annotation check in the ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: debug-statements
+- repo: http://github.com/pre-commit/mirrors-mypy
+  rev: v1.16.0
+  hooks:
+  - id: mypy
+    additional_dependencies:
+    - types-PyYAML

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,8 @@ pytest = "==8.3.5"
 pre-commit = "==4.2.0"
 black = "==25.1.0"
 mock = "*"
+mypy = "==1.16.0"
+types-pyyaml = "==6.0.12.20250516"
 
 [packages]
 py-healthcheck = "==1.10.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "914d97c59808a7a239ad1a95515ad18d59dac1382fc72b053e7f7131dcc3a405"
+            "sha256": "4e48c61badbb58d52bb444f54481902249bb323e08e7099ef258d834d09a2573"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -673,6 +673,45 @@
             "markers": "python_version >= '3.6'",
             "version": "==5.2.0"
         },
+        "mypy": {
+            "hashes": [
+                "sha256:021a68568082c5b36e977d54e8f1de978baf401a33884ffcea09bd8e88a98f4c",
+                "sha256:089bedc02307c2548eb51f426e085546db1fa7dd87fbb7c9fa561575cf6eb1ff",
+                "sha256:09a8da6a0ee9a9770b8ff61b39c0bb07971cda90e7297f4213741b48a0cc8d93",
+                "sha256:0b07e107affb9ee6ce1f342c07f51552d126c32cd62955f59a7db94a51ad12c0",
+                "sha256:15486beea80be24ff067d7d0ede673b001d0d684d0095803b3e6e17a886a2a92",
+                "sha256:29e1499864a3888bca5c1542f2d7232c6e586295183320caa95758fc84034031",
+                "sha256:2e7e0ad35275e02797323a5aa1be0b14a4d03ffdb2e5f2b0489fa07b89c67b21",
+                "sha256:4086883a73166631307fdd330c4a9080ce24913d4f4c5ec596c601b3a4bdd777",
+                "sha256:54066fed302d83bf5128632d05b4ec68412e1f03ef2c300434057d66866cea4b",
+                "sha256:55f9076c6ce55dd3f8cd0c6fff26a008ca8e5131b89d5ba6d86bd3f47e736eeb",
+                "sha256:6a2322896003ba66bbd1318c10d3afdfe24e78ef12ea10e2acd985e9d684a666",
+                "sha256:7909541fef256527e5ee9c0a7e2aeed78b6cda72ba44298d1334fe7881b05c5c",
+                "sha256:82d056e6faa508501af333a6af192c700b33e15865bda49611e3d7d8358ebea2",
+                "sha256:84b94283f817e2aa6350a14b4a8fb2a35a53c286f97c9d30f53b63620e7af8ab",
+                "sha256:936ccfdd749af4766be824268bfe22d1db9eb2f34a3ea1d00ffbe5b5265f5491",
+                "sha256:9f826aaa7ff8443bac6a494cf743f591488ea940dd360e7dd330e30dd772a5ab",
+                "sha256:a5fcfdb7318c6a8dd127b14b1052743b83e97a970f0edb6c913211507a255e20",
+                "sha256:a7e32297a437cc915599e0578fa6bc68ae6a8dc059c9e009c628e1c47f91495d",
+                "sha256:a9e056237c89f1587a3be1a3a70a06a698d25e2479b9a2f57325ddaaffc3567b",
+                "sha256:afe420c9380ccec31e744e8baff0d406c846683681025db3531b32db56962d52",
+                "sha256:b4968f14f44c62e2ec4a038c8797a87315be8df7740dc3ee8d3bfe1c6bf5dba8",
+                "sha256:bd4e1ebe126152a7bbaa4daedd781c90c8f9643c79b9748caa270ad542f12bec",
+                "sha256:c5436d11e89a3ad16ce8afe752f0f373ae9620841c50883dc96f8b8805620b13",
+                "sha256:c6fb60cbd85dc65d4d63d37cb5c86f4e3a301ec605f606ae3a9173e5cf34997b",
+                "sha256:d045d33c284e10a038f5e29faca055b90eee87da3fc63b8889085744ebabb5a1",
+                "sha256:e71d6f0090c2256c713ed3d52711d01859c82608b5d68d4fa01a3fe30df95571",
+                "sha256:eb14a4a871bb8efb1e4a50360d4e3c8d6c601e7a31028a2c79f9bb659b63d730",
+                "sha256:eb5fbc8063cb4fde7787e4c0406aa63094a34a2daf4673f359a1fb64050e9cb2",
+                "sha256:f2622af30bf01d8fc36466231bdd203d120d7a599a6d88fb22bdcb9dbff84090",
+                "sha256:f2ed0e0847a80655afa2c121835b848ed101cc7b8d8d6ecc5205aedc732b1436",
+                "sha256:f56236114c425620875c7cf71700e3d60004858da856c6fc78998ffe767b73d3",
+                "sha256:feec38097f71797da0231997e0de3a58108c51845399669ebc532c815f93866b"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.16.0"
+        },
         "mypy-extensions": {
             "hashes": [
                 "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505",
@@ -836,6 +875,15 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2.2.1"
+        },
+        "types-pyyaml": {
+            "hashes": [
+                "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530",
+                "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==6.0.12.20250516"
         },
         "typing-extensions": {
             "hashes": [

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.9
+ignore_missing_imports = True
+disable_error_code = annotation-unchecked, var-annotated, misc, index


### PR DESCRIPTION
you can run the type annotation check via
```
$ mypy .
```
(in that case the configuration from `mypy.ini`  file is used

------

or as part of pre-commit check
```
$ pre-commit run -av
```

-------

the check will be now part of the [pre-commit](https://github.com/RedHatInsights/turnpike/actions/workflows/pre-commit.yml) github action too
