### PR TITLE
RHCLOUD-33532 | chore: gate Nginx backend matching by header

### DIFF
--- a/templates/web.yml
+++ b/templates/web.yml
@@ -70,6 +70,8 @@ objects:
                     name: gateway-secret
               - name: AUTH_DEBUG
                 value: "${AUTH_DEBUG}"
+              - name: NGINX_HEADER_BACKEND_MATCHING_ENABLED
+                value: ${NGINX_HEADER_BACKEND_MATCHING_ENABLED}
             image: ${IMAGE}:${IMAGE_TAG}
             imagePullPolicy: Always
             name: web
@@ -223,3 +225,6 @@ parameters:
 - description: Replica count for turnpike-web
   name: REPLICAS
   value: "1"
+- description: Enables matching back ends by the "X-Matched-Backend" header Nginx forwards, instead of relying on parsing the route. Temporary variable.
+  name: NGINX_HEADER_BACKEND_MATCHING_ENABLED
+  value: "false"

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -26,6 +26,7 @@ class TestMatchingBackends(unittest.TestCase):
                 "HEADER_CERTAUTH_SUBJECT": "subject",
                 "HEADER_CERTAUTH_ISSUER": "issuer",
                 "HEADER_CERTAUTH_PSK": "test-psk",
+                "NGINX_HEADER_BACKEND_MATCHING_ENABLED": True,
                 "PLUGIN_CHAIN": [
                     "tests.mocked_plugins.mocked_plugin.MockPlugin",
                 ],

--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -39,3 +39,8 @@ DEFAULT_RESPONSE_CODE = 200
 
 with open(os.environ["BACKENDS_CONFIG_MAP"]) as ifs:
     BACKENDS = yaml.safe_load(ifs)
+
+# To be removed once https://github.com/RedHatInsights/turnpike/pull/385 is merged.
+NGINX_HEADER_BACKEND_MATCHING_ENABLED = (
+    "true" == os.environ.get("NGINX_HEADER_BACKEND_MATCHING_ENABLED", "false").lower()
+)

--- a/turnpike/views.py
+++ b/turnpike/views.py
@@ -17,7 +17,7 @@ def policy_view():
     current_app.logger.debug(f"Received original URI: {original_url}")
     current_app.logger.debug(f"Matched back end in NGINX: {nginx_matched_backend}")
 
-    if nginx_matched_backend:
+    if current_app.config.get("NGINX_HEADER_BACKEND_MATCHING_ENABLED") and nginx_matched_backend:
         context.backend = match_by_backend_name(nginx_matched_backend)
     else:
         context.backend = match_by_route(original_url)


### PR DESCRIPTION
Until the PR that matches the back end by the header Nginx sends to Turnpike[1] gets merged and tested, we need to gate this way of matching the back ends in Turnpike behind a feature flag.

[1]: https://github.com/RedHatInsights/turnpike/pull/385

## Jira ticket
[[RHCLOUD-33532]](https://issues.redhat.com/browse/RHCLOUD-33532)