### PR TITLE
[DO NOT MERGE] update Dockerfile-prometheus to use nginx-prometheus-exporter quay image

### DIFF
--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -1,11 +1,11 @@
+FROM ghcr.io/nginx/nginx-prometheus-exporter:1.4.2 as build
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1749489516
+
+COPY --from=build . /usr/bin/nginx-prometheus-exporter
 
 USER root
 
 ENV SCRAPE_URI=http://localhost:8080/stub_status
 
-RUN microdnf install -y git-core make go
-RUN git clone --branch v1.4.1 https://github.com/nginxinc/nginx-prometheus-exporter
-RUN cd nginx-prometheus-exporter && make && chmod +x ./nginx-prometheus-exporter
-
-CMD ./nginx-prometheus-exporter/nginx-prometheus-exporter --nginx.scrape-uri $SCRAPE_URI
+CMD nginx-prometheus-exporter -nginx.scrape-uri $SCRAPE_URI


### PR DESCRIPTION
-  the current `turnpike-nginx-prometheus` image contains several known vulnerabilities that have been addressed in `nginx-prometheus-exporter` version 1.4.2
- however version 1.4.2 requires Golang 1.24.2, which is not yet supported by the latest `ubi9/ubi-minimal` base image (limited to Go 1.23.9) -> as a result, building the exporter directly in this environment is not feasible
- as a solution, this PR replaces the local build with the official `nginx-prometheus-exporter` image from Quay, executed from within the `ubi9/ubi-minimal` environment
- this approach not only addresses the vulnerabilities but also reduces the final image size and speeds up the build process