### PR TITLE
RHCLOUD-30610 | fix: the "oidc" plugin is not skipped

### DIFF
--- a/tests/test_oidc_plugin.py
+++ b/tests/test_oidc_plugin.py
@@ -1,3 +1,4 @@
+import copy
 import http
 import unittest
 import uuid
@@ -122,23 +123,23 @@ class TestMatchingBackends(TestCase):
 
             return response
 
-    def test_missing_jwt_backend(self):
-        """Test that an internal server error is returned when the passed back end to the JWT plugin is not a 'jwt' back end."""
-        # Set up a mock for the context.
+    def test_missing_oidc_backend_skips_plugin(self):
+        """Test that when the specified backend does not have an "oidc" authorization section, the "oidc" plugin is skipped."""
         context = mock.Mock
 
         # Assert that a log message is produced.
-        with self.assertLogs(self.app.logger.name, level="ERROR") as cm:
+        with self.assertLogs(self.app.logger.name, level="DEBUG") as cm:
             # Call the function under test.
             self.oidc_jwt_plugin.process(context=context, backend_auth={})
 
             # Ensure that the correct log message has been issued.
             self.assertTrue(
-                'A "JWT" back end was matched, but the back end does not have a "JWT" section defined:' in cm.output[0]
+                'The back end does not have an "oidc" authorization key defined. Skipping "oidc" authorization plugin'
+                in cm.output[0]
             )
 
-            # Ensure that the context contains the expected status code.
-            self.assertEqual(http.HTTPStatus.INTERNAL_SERVER_ERROR, context.status_code)
+            # Ensure that the context contains the default status code.
+            self.assertEqual(http.HTTPStatus.UNAUTHORIZED, context.status_code)
 
     def test_missing_bearer_token(self):
         """Test that when the bearer token is not present, an unauthorized status code is set in the context."""

--- a/turnpike/plugins/oidc/oidc.py
+++ b/turnpike/plugins/oidc/oidc.py
@@ -88,12 +88,13 @@ class OIDCAuthPlugin(TurnpikeAuthPlugin):
             raise UnableCreateKeysetError(f"Unable to create a keyset from the JWKS certificates: {e}")
 
     def process(self, context, backend_auth: Dict[str, Dict[str, list[Dict[str, Union[str, list[str]]]]]]):
+        # When the given backend does not have an "oidc" section defined, we simply "skip" this plugin by returning
+        # the unmodified context.
         if not "oidc" in backend_auth:
-            self.app.logger.error(
-                f'A "JWT" back end was matched, but the back end does not have a "JWT" section defined: {backend_auth}'
+            self.app.logger.debug(
+                'The back end does not have an "oidc" authorization key defined. Skipping "oidc" authorization plugin'
             )
 
-            context.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
             return context
 
         # Check that the "Authorization" header was sent.


### PR DESCRIPTION
When a back end did not have an "oidc" section in the "auth" section, the plug in was returning "500" errors, when it should simply be skipping the authorization attempt for that back end.

The reason for this was that I mistakenly understood that if a plug in gets executed, that meant that the back end had an authorization section defined for that plug in.

However, in reality, Turnpike loops through the plug ins and skips the authorization when there is no section defined in the "auth" key for that plugin.

## Jira ticket
[[RHCLOUD-30610]](https://issues.redhat.com/browse/RHCLOUD-30610)