### PR TITLE
RHCLOUD-33532 | fix: partially revert Nginx location matching

### DIFF
--- a/nginx/configuration_builder/templates/nginx_location_template.conf.j2
+++ b/nginx/configuration_builder/templates/nginx_location_template.conf.j2
@@ -1,4 +1,15 @@
-    location {{ route }} {
+    # The regex is used so that the capture group then can be appended to the $upstream variable after the
+    # authentication is successful.
+    #
+    # For example, for a back end defined as so:
+    #
+    # - Origin: http://my-service.service.local
+    # - Route: /api/my-service
+    #
+    # If a request gets sent to "/api/my-service/resource/subresource", the "/resource/subresource" part
+    # gets captured by the regex group, and applied to the "proxy_pass" directive after the "$upstream"
+    # variable, which results in the following URL: "http://my-service.service.local/resource/subresource".
+    location ~ {{ route }}(.*)$ {
         resolver {{ resolver }} valid=60s;
         set $upstream  {{ origin }};
         set $matched_backend {{ name }};

--- a/templates/web.yml
+++ b/templates/web.yml
@@ -70,6 +70,8 @@ objects:
                     name: gateway-secret
               - name: AUTH_DEBUG
                 value: "${AUTH_DEBUG}"
+              - name: NGINX_HEADER_BACKEND_MATCHING_ENABLED
+                value: ${NGINX_HEADER_BACKEND_MATCHING_ENABLED}
               - name: SSO_OIDC_HOST
                 value: ${SSO_OIDC_HOST}
               - name: SSO_OIDC_PORT
@@ -231,6 +233,9 @@ parameters:
 - description: Replica count for turnpike-web
   name: REPLICAS
   value: "1"
+- description: Enables matching back ends by the "X-Matched-Backend" header Nginx forwards, instead of relying on parsing the route. Temporary variable.
+  name: NGINX_HEADER_BACKEND_MATCHING_ENABLED
+  value: "false"
 - description: The host of the Single Sign On service that supports OIDC authentication and authorization.
   name: SSO_OIDC_HOST
   value: localhost

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -27,6 +27,7 @@ class TestMatchingBackends(unittest.TestCase):
                 "HEADER_CERTAUTH_SUBJECT": "subject",
                 "HEADER_CERTAUTH_ISSUER": "issuer",
                 "HEADER_CERTAUTH_PSK": "test-psk",
+                "NGINX_HEADER_BACKEND_MATCHING_ENABLED": True,
                 "PLUGIN_CHAIN": [
                     "tests.mocked_plugins.mocked_plugin.MockPlugin",
                 ],

--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -65,3 +65,8 @@ DEFAULT_RESPONSE_CODE = 200
 
 with open(os.environ["BACKENDS_CONFIG_MAP"]) as ifs:
     BACKENDS = yaml.safe_load(ifs)
+
+# To be removed once https://github.com/RedHatInsights/turnpike/pull/385 is merged.
+NGINX_HEADER_BACKEND_MATCHING_ENABLED = (
+    "true" == os.environ.get("NGINX_HEADER_BACKEND_MATCHING_ENABLED", "false").lower()
+)

--- a/turnpike/views.py
+++ b/turnpike/views.py
@@ -17,7 +17,7 @@ def policy_view():
     current_app.logger.debug(f"Received original URI: {original_url}")
     current_app.logger.debug(f"Matched back end in NGINX: {nginx_matched_backend}")
 
-    if nginx_matched_backend:
+    if current_app.config.get("NGINX_HEADER_BACKEND_MATCHING_ENABLED") and nginx_matched_backend:
         context.backend = match_by_backend_name(nginx_matched_backend)
     else:
         context.backend = match_by_route(original_url)


### PR DESCRIPTION
The reason why regex was being used for the location matching was because the captured group was being passed to the "proxy_pass" as the "$1" argument. So, for a backend like this one...

- Origin: http://my-service.svc.cluster.local
- Route: /api/my-service

... and a request sent to "/api/my-service/resource/subresource", the following URL was constructed in Nginx:

- http://my-service.svc.cluster.local/resource/subresource

I still believe it would be benefitial to move away from regex matchings since it would make our lives easier, but until we figure out a solution to appending the URI I'll revert the changes to unblock other teams.

## Jira ticket
[[RHCLOUD-33532]](https://issues.redhat.com/browse/RHCLOUD-33532)