### PR TITLE
allow backends to be restricted to vpn only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 AUTH_DEBUG=1
 FLASK_ENV=development
+WEB_ENV=dev
 MULTI_VALUE_SAML_ATTRS=Role
 PYTHONUNBUFFERED=1
 SECRET_KEY=
@@ -8,4 +9,4 @@ SSO_OIDC_HOST=sso.domain.com
 SSO_OIDC_PORT=443
 SSO_OIDC_PROTOCOL_SCHEME=https
 SSO_OIDC_REALM=realm
-TURNPIKE_ALLOWED_ORIGIN_DOMAINS=web,echo-server,foo,host.docker.internal
+TURNPIKE_ALLOWED_ORIGIN_DOMAINS=["web","echo-server","foo","host.docker.internal",".svc.cluster.local"]

--- a/dev-backends.yml
+++ b/dev-backends.yml
@@ -28,3 +28,7 @@
 - name: nginx_regression_test
   route: /api/does_not_exist/
   origin: http://foo:5000/does_not_exist/
+- name: vpn_restricted_api
+  route: /public/vpn/echo/
+  private: true
+  origin: http://echo-server.svc.cluster.local:8080/vpn/echo/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,13 +25,15 @@ services:
       context: ./nginx
       dockerfile: Dockerfile
     ports:
-      - 443:8443
+      - 8443:8443
+    env_file:
+      - ./.env
     depends_on:
       - web
     hostname: nginx
     volumes:
-      - "./dev-backends.yml:/etc/turnpike/backends.yml"
-      - "./nginx/certs:/etc/nginx/certs"
+      - "./dev-backends.yml:/etc/turnpike/backends.yml:Z"
+      - "./nginx/certs:/etc/nginx/certs:Z"
     networks:
       mynet:
         aliases:

--- a/templates/web.yml
+++ b/templates/web.yml
@@ -220,6 +220,7 @@ parameters:
 - description: The environment turnpike web is running in
   name: WEB_ENV
   required: true
+  value: stage
 - description: Service name for Redis
   name: REDIS_SERVICE_NAME
   required: true

--- a/templates/web.yml
+++ b/templates/web.yml
@@ -56,6 +56,8 @@ objects:
                 value: "${FLASK_SERVER_NAME}"
               - name: FLASK_ENV
                 value: "${FLASK_ENV}"
+              - name: WEB_ENV
+                value: "${WEB_ENV}"
               - name: REDIS_HOST
                 valueFrom:
                   secretKeyRef:
@@ -214,6 +216,9 @@ parameters:
 - description: Value for FLASK_ENV
   name: FLASK_ENV
   value: production
+  required: true
+- description: The environment turnpike web is running in
+  name: WEB_ENV
   required: true
 - description: Service name for Redis
   name: REDIS_SERVICE_NAME

--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -19,6 +19,8 @@ SESSION_REDIS = redis.Redis(
     password=os.environ.get("REDIS_PASSWORD"),
 )
 
+WEB_ENV = os.environ.get("WEB_ENV")
+
 # Cache configuration for Flask-Caching.
 CACHE_TYPE = "RedisCache"
 CACHE_REDIS_URL = f'redis://{os.environ.get("REDIS_USERNAME")}:{os.environ.get("REDIS_PASSWORD")}@{os.environ.get("REDIS_HOST", "redis")}'
@@ -48,6 +50,7 @@ if not SSO_OIDC_REALM:
     raise ValueError("No SSO_OIDC_REALM set.")
 
 PLUGIN_CHAIN = [
+    "turnpike.plugins.vpn.VPNPlugin",
     "turnpike.plugins.auth.AuthPlugin",
     "turnpike.plugins.source_ip.SourceIPPlugin",
     "turnpike.plugins.rh_identity.RHIdentityPlugin",

--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -19,7 +19,7 @@ SESSION_REDIS = redis.Redis(
     password=os.environ.get("REDIS_PASSWORD"),
 )
 
-WEB_ENV = os.environ.get("WEB_ENV")
+WEB_ENV = os.environ.get("WEB_ENV", "dev")
 
 # Cache configuration for Flask-Caching.
 CACHE_TYPE = "RedisCache"

--- a/turnpike/plugins/vpn.py
+++ b/turnpike/plugins/vpn.py
@@ -1,0 +1,82 @@
+import logging
+import re
+
+from http import HTTPStatus
+from flask import request
+
+from ..plugin import TurnpikePlugin
+
+
+class VPNPlugin(TurnpikePlugin):
+    vpn_pattern = r"(mtls\.|)private\.(console|cloud)\.(stage\.|dev\.|)redhat\.com"
+    edge_host_header = "x-rh-edge-host"
+    vpn_config_key = "private"
+    
+    def __init__(self, app):
+        self.vpn_regex = re.compile(self.vpn_pattern)
+        self.env = app.config.get("WEB_ENV").casefold()
+        self.headers_needed = set(self.edge_host_header)
+        
+        super().__init__(app)
+    
+    def process(self, context):
+        self.app.logger.info("env: %s", self.env)
+        if self.vpn_config_key not in context.backend or context.backend[self.vpn_config_key] != True:
+            return context
+        
+        edge_host = request.headers.get(self.edge_host_header)
+        backend_name = context.backend["name"]
+        
+        if not edge_host:
+            # TODO: integrate glitchtip with turnpike and capture this so we get alert if it happens, see https://issues.redhat.com/browse/RHCLOUD-40788
+            return self.forbidden(
+                context, 
+                logging.WARNING, 
+                "request to backend '%s' denied - missing '%s' header which is required for vpn restricted backend", 
+                backend_name,
+                self.edge_host_header
+            )
+        
+        match = self.vpn_regex.fullmatch(edge_host)
+        
+        if not match:
+            return self.forbidden(
+                context, 
+                logging.DEBUG,
+                "request to backend '%s' denied - '%s':'%s' does not originate from vpn restricted edge host", 
+                backend_name, 
+                self.edge_host_header, 
+                edge_host
+            )
+        
+        match_env = match.groups()[2]
+        if self.is_production() and match_env != '':
+            return self.forbidden(
+                context, 
+                logging.INFO,
+                "request to backend '%s' denied - '%s':'%s' is from edge host in wrong env, expected prod host", 
+                backend_name, 
+                self.edge_host_header, 
+                edge_host
+            )
+        elif not self.is_production() and match_env == '':
+            return self.forbidden(
+                context, 
+                logging.INFO, 
+                "request to backend '%s' denied - '%s':'%s' is from edge host in wrong env, expected non prod host", 
+                backend_name, 
+                self.edge_host_header, 
+                edge_host
+            )
+        
+        
+        self.app.logger.debug("request to backend '%s' approved - '%s':'%s' is valid for vpn restricted backend", backend_name, self.edge_host_header, edge_host)
+        return context
+    
+    def forbidden(self, context, level, msg, *args, **kwargs):
+        self.app.logger.log(level, msg, *args, **kwargs)
+        context.status_code = HTTPStatus.FORBIDDEN
+        return context
+    
+    def is_production(self):
+        return self.env == "prod" or self.env == "production"

--- a/turnpike/plugins/vpn.py
+++ b/turnpike/plugins/vpn.py
@@ -11,72 +11,76 @@ class VPNPlugin(TurnpikePlugin):
     vpn_pattern = r"(mtls\.|)private\.(console|cloud)\.(stage\.|dev\.|)redhat\.com"
     edge_host_header = "x-rh-edge-host"
     vpn_config_key = "private"
-    
+
     def __init__(self, app):
         self.vpn_regex = re.compile(self.vpn_pattern)
         self.env = app.config.get("WEB_ENV").casefold()
         self.headers_needed = set(self.edge_host_header)
-        
+
         super().__init__(app)
-    
+
     def process(self, context):
         self.app.logger.info("env: %s", self.env)
         if self.vpn_config_key not in context.backend or context.backend[self.vpn_config_key] != True:
             return context
-        
+
         edge_host = request.headers.get(self.edge_host_header)
         backend_name = context.backend["name"]
-        
+
         if not edge_host:
             # TODO: integrate glitchtip with turnpike and capture this so we get alert if it happens, see https://issues.redhat.com/browse/RHCLOUD-40788
             return self.forbidden(
-                context, 
-                logging.WARNING, 
-                "request to backend '%s' denied - missing '%s' header which is required for vpn restricted backend", 
+                context,
+                logging.WARNING,
+                "request to backend '%s' denied - missing '%s' header which is required for vpn restricted backend",
                 backend_name,
-                self.edge_host_header
+                self.edge_host_header,
             )
-        
+
         match = self.vpn_regex.fullmatch(edge_host)
-        
+
         if not match:
             return self.forbidden(
-                context, 
+                context,
                 logging.DEBUG,
-                "request to backend '%s' denied - '%s':'%s' does not originate from vpn restricted edge host", 
-                backend_name, 
-                self.edge_host_header, 
-                edge_host
+                "request to backend '%s' denied - '%s':'%s' does not originate from vpn restricted edge host",
+                backend_name,
+                self.edge_host_header,
+                edge_host,
             )
-        
+
         match_env = match.groups()[2]
-        if self.is_production() and match_env != '':
+        if self.is_production() and match_env != "":
             return self.forbidden(
-                context, 
+                context,
                 logging.INFO,
-                "request to backend '%s' denied - '%s':'%s' is from edge host in wrong env, expected prod host", 
-                backend_name, 
-                self.edge_host_header, 
-                edge_host
+                "request to backend '%s' denied - '%s':'%s' is from edge host in wrong env, expected prod host",
+                backend_name,
+                self.edge_host_header,
+                edge_host,
             )
-        elif not self.is_production() and match_env == '':
+        elif not self.is_production() and match_env == "":
             return self.forbidden(
-                context, 
-                logging.INFO, 
-                "request to backend '%s' denied - '%s':'%s' is from edge host in wrong env, expected non prod host", 
-                backend_name, 
-                self.edge_host_header, 
-                edge_host
+                context,
+                logging.INFO,
+                "request to backend '%s' denied - '%s':'%s' is from edge host in wrong env, expected non prod host",
+                backend_name,
+                self.edge_host_header,
+                edge_host,
             )
-        
-        
-        self.app.logger.debug("request to backend '%s' approved - '%s':'%s' is valid for vpn restricted backend", backend_name, self.edge_host_header, edge_host)
+
+        self.app.logger.debug(
+            "request to backend '%s' approved - '%s':'%s' is valid for vpn restricted backend",
+            backend_name,
+            self.edge_host_header,
+            edge_host,
+        )
         return context
-    
+
     def forbidden(self, context, level, msg, *args, **kwargs):
         self.app.logger.log(level, msg, *args, **kwargs)
         context.status_code = HTTPStatus.FORBIDDEN
         return context
-    
+
     def is_production(self):
         return self.env == "prod" or self.env == "production"

--- a/turnpike/plugins/vpn.py
+++ b/turnpike/plugins/vpn.py
@@ -8,7 +8,7 @@ from ..plugin import TurnpikePlugin
 
 
 class VPNPlugin(TurnpikePlugin):
-    vpn_pattern = r"(mtls\.|)private\.(console|cloud)\.(stage\.|dev\.|)redhat\.com"
+    vpn_pattern = r"(?:mtls\.)?private\.(?:console|cloud)\.(?:(stage|dev)\.)?redhat\.com"
     edge_host_header = "x-rh-edge-host"
     vpn_config_key = "private"
 
@@ -20,7 +20,6 @@ class VPNPlugin(TurnpikePlugin):
         super().__init__(app)
 
     def process(self, context):
-        self.app.logger.info("env: %s", self.env)
         if self.vpn_config_key not in context.backend or context.backend[self.vpn_config_key] != True:
             return context
 
@@ -49,8 +48,8 @@ class VPNPlugin(TurnpikePlugin):
                 edge_host,
             )
 
-        match_env = match.groups()[2]
-        if self.is_production() and match_env != "":
+        match_env = match.groups()[0]
+        if self.is_production() and match_env:
             return self.forbidden(
                 context,
                 logging.INFO,
@@ -59,7 +58,7 @@ class VPNPlugin(TurnpikePlugin):
                 self.edge_host_header,
                 edge_host,
             )
-        elif not self.is_production() and match_env == "":
+        elif not self.is_production() and not match_env:
             return self.forbidden(
                 context,
                 logging.INFO,


### PR DESCRIPTION
## Summary 
Add the option to require users be on vpn for a backend/api

### How
Akamai has exposed new domains that are restricted behind the vpn:
```
private.console.redhat.com
private.cloud.redhat.com

private.console.stage.redhat.com
private.cloud.stage.redhat.com
```

So to restrict a backend to be vpn only, we need to enforce that the request came from one of those domains. I did this via creating a new turnpike plugin that will check backend config to see if it is vpn only, and if yes, verify the request came from `private.*` by examining the `x-rh-edge-host` header that akami sets on incoming requests.

The turnpike backend config now has a new `private` option:
```
- name: vpn_restricted_api
  route: /api/vpn-only/
  private: true
  origin: http://my-service.svc.cluster.local:8080/api/vpn-only/
  auth: 
    saml: "True"
    x509: "True"
```
This is the field that turnpike will look for to check if we should restrict the backend to vpn. If its set to false or not present, we do not restrict the backend.

I also added a bit of extra protection to ensure we are accepting traffic from the right env. There is a new env var `WEB_ENV` that will be set to `prod|stage|dev...` etc. If its set to `prod`, we ensure `x-rh-edge-host` is `private.console.redhat.com`. If set to anything else, we ensure it is set to `private.console.(stage|dev).redhat.com`. This is a bit extra defensive, but will just ensure we don't accidentally accept prod traffic into stage from `private.*` or vice versa. 

MR opened to set this var in our deployments, I will make sure that merges first.

### Ticket
https://issues.redhat.com/browse/RHCLOUD-37506