### PR TITLE
RHCLOUD-33532 | feature: enable back end matching by name by default

### DIFF
--- a/templates/web.yml
+++ b/templates/web.yml
@@ -75,8 +75,6 @@ objects:
                     name: gateway-secret
               - name: AUTH_DEBUG
                 value: "${AUTH_DEBUG}"
-              - name: NGINX_HEADER_BACKEND_MATCHING_ENABLED
-                value: ${NGINX_HEADER_BACKEND_MATCHING_ENABLED}
               - name: SSO_OIDC_HOST
                 value: ${SSO_OIDC_HOST}
               - name: SSO_OIDC_PORT
@@ -267,9 +265,6 @@ parameters:
 - description: Replica count for turnpike-web
   name: REPLICAS
   value: "1"
-- description: Enables matching back ends by the "X-Matched-Backend" header Nginx forwards, instead of relying on parsing the route. Temporary variable.
-  name: NGINX_HEADER_BACKEND_MATCHING_ENABLED
-  value: "false"
 - description: The host of the Single Sign On service that supports OIDC authentication and authorization.
   name: SSO_OIDC_HOST
   value: localhost

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -28,7 +28,6 @@ class TestMatchingBackends(unittest.TestCase):
                 "HEADER_CERTAUTH_SUBJECT": "subject",
                 "HEADER_CERTAUTH_ISSUER": "issuer",
                 "HEADER_CERTAUTH_PSK": "test-psk",
-                "NGINX_HEADER_BACKEND_MATCHING_ENABLED": True,
                 "PLUGIN_CHAIN": [
                     "tests.mocked_plugins.mocked_plugin.MockPlugin",
                 ],

--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -83,8 +83,3 @@ DEFAULT_RESPONSE_CODE = 200
 
 with open(os.environ["BACKENDS_CONFIG_MAP"]) as ifs:
     BACKENDS = yaml.safe_load(ifs)
-
-# To be removed once https://github.com/RedHatInsights/turnpike/pull/385 is merged.
-NGINX_HEADER_BACKEND_MATCHING_ENABLED = (
-    "true" == os.environ.get("NGINX_HEADER_BACKEND_MATCHING_ENABLED", "false").lower()
-)

--- a/turnpike/views/views.py
+++ b/turnpike/views/views.py
@@ -17,7 +17,7 @@ def policy_view():
     current_app.logger.debug(f"Received original URI: {original_url}")
     current_app.logger.debug(f"Matched back end in NGINX: {nginx_matched_backend}")
 
-    if current_app.config.get("NGINX_HEADER_BACKEND_MATCHING_ENABLED") and nginx_matched_backend:
+    if nginx_matched_backend:
         context.backend = match_by_backend_name(nginx_matched_backend)
     else:
         context.backend = match_by_route(original_url)


### PR DESCRIPTION
The changes have been tested in stage and everything seems to work as intended, so we should be good to remove the safety flag.

## Jira ticket
[[RHCLOUD-33532]](https://issues.redhat.com/browse/RHCLOUD-33532)