### PR TITLE
RHCLOUD-37506 | fix: the Nginx pod keeps crashlooping

### DIFF
--- a/nginx/configuration_builder/build_config.py
+++ b/nginx/configuration_builder/build_config.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import socket
 import sys
 import time
 import typing
@@ -98,7 +99,7 @@ def main(args):
     request_obj = request.Request(
         f'{os.environ["FLASK_SERVICE_URL"]}/_nginx_config/',
         headers={
-            "X-Forwarded-Host": os.environ["FLASK_SERVER_NAME"],
+            "X-Forwarded-Host": socket.gethostname(),
             "X-Forwarded-Port": "443",
             "X-Forwarded-Proto": "https",
         },


### PR DESCRIPTION
The Nginx pod is crashlooping because the "FLASK_SERVER_NAME" environment variable got removed, but I forgot to remove it from the "build_configuration" script.

Since calling the Flask application to fetch the configuration is going away soon, we can simply grab Nginx's hostname to fetch the configuration.

## Jira ticket
[[RHCLOUD-37506]](https://issues.redhat.com/browse/RHCLOUD-37506)