### PR TITLE
RHCLOUD-37506 | revert: fix flask server name removal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       NGINX_LISTEN: 8443 ssl
       NGINX_SERVER_NAME: ${SERVER_NAME}
       NGINX_VPN_SERVER_NAME: ${VPN_SERVER_NAME}
+      FLASK_SERVER_NAME: ${SERVER_NAME}
       FLASK_SERVICE_URL: http://web.svc.cluster.local:5000
       NGINX_SSL_CONFIG: |
        ssl_certificate certs/cert.pem;

--- a/nginx/configuration_builder/build_config.py
+++ b/nginx/configuration_builder/build_config.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import re
-import socket
 import sys
 import time
 import typing
@@ -99,7 +98,7 @@ def main(args):
     request_obj = request.Request(
         f'{os.environ["FLASK_SERVICE_URL"]}/_nginx_config/',
         headers={
-            "X-Forwarded-Host": socket.gethostname(),
+            "X-Forwarded-Host": os.environ["FLASK_SERVER_NAME"],
             "X-Forwarded-Port": "443",
             "X-Forwarded-Proto": "https",
         },

--- a/nginx/configuration_builder/templates/api_gateway.conf.j2
+++ b/nginx/configuration_builder/templates/api_gateway.conf.j2
@@ -5,6 +5,11 @@ server {
     server_name_in_redirect on;
     {{ NGINX_SSL_CONFIG }}
     include      api_conf.d/*.conf;
+    set          $proxy_host {{ FLASK_SERVER_NAME }};
+
+    if ($proxy_host = "") {
+        set $proxy_host $host;
+    }
 
     location /_nginx/ {
         access_log off;
@@ -27,7 +32,7 @@ server {
         proxy_set_header        referer $http_referer;
         proxy_set_header        X-Original-URI $request_uri;
         proxy_set_header        X-Real-IP $remote_addr;
-        proxy_set_header        X-Forwarded-Host $host;
+        proxy_set_header        X-Forwarded-Host $proxy_host;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header        X-Forwarded-Port 443;
         proxy_set_header        X-Forwarded-Proto https;
@@ -42,7 +47,7 @@ server {
         proxy_pass              {{ FLASK_SERVICE_URL }};
         proxy_set_header        X-Original-URI $request_uri;
         proxy_set_header        X-Real-IP $remote_addr;
-        proxy_set_header        X-Forwarded-Host $host;
+        proxy_set_header        X-Forwarded-Host $proxy_host;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header        X-Forwarded-Port 443;
         proxy_set_header        X-Forwarded-Proto https;

--- a/nginx/configuration_builder/templates/nginx_location_template.conf.j2
+++ b/nginx/configuration_builder/templates/nginx_location_template.conf.j2
@@ -52,7 +52,7 @@
         proxy_pass              $uri;
         proxy_set_header        X-Original-URI $request_uri;
         proxy_set_header        X-Real-IP $remote_addr;
-        proxy_set_header        X-Forwarded-Host $host;
+        proxy_set_header        X-Forwarded-Host $proxy_host;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header        X-Forwarded-Port 443;
         proxy_set_header        X-Forwarded-Proto https;

--- a/templates/nginx.yml
+++ b/templates/nginx.yml
@@ -46,6 +46,8 @@ objects:
               value: "${NGINX_SERVER_NAME}"
             - name: NGINX_VPN_SERVER_NAME
               value: "${NGINX_VPN_SERVER_NAME}"
+            - name: FLASK_SERVER_NAME
+              value: "${FLASK_SERVER_NAME}"
             - name: FLASK_SERVICE_URL
               value: "${FLASK_SERVICE_URL}"
             - name: NGINX_SSL_CONFIG
@@ -153,6 +155,9 @@ parameters:
 - description: Domains allowed to be routed to
   name: ALLOWED_ORIGIN_DOMAINS
   value: '[".svc.cluster.local"]'
+  required: true
+- description: Effective hostname for this service
+  name: FLASK_SERVER_NAME
   required: true
 - description: URL to Flask service
   name: FLASK_SERVICE_URL


### PR DESCRIPTION
The Flask server name's removal is causing issues when fetching the
session from Turnpike, because when the configuration is loaded from the
Flask application when Nginx is booting, the "X-Forwarded-Host" header
contains the improper hostname.

## Jira ticket
[[RHCLOUD-37506]](https://issues.redhat.com/browse/RHCLOUD-37506)