### PR TITLE
 RHCLOUD-37506 | fix: MTLS requests denied for non-private backends

### DIFF
--- a/tests/test_header_validator.py
+++ b/tests/test_header_validator.py
@@ -1,0 +1,124 @@
+import http
+import uuid
+from unittest import TestCase
+from unittest.mock import Mock
+
+from turnpike import create_app
+from turnpike.plugins.common.header_validator import HeaderValidator
+from turnpike.plugins.common.invalid_header_error import InvalidHeaderError
+
+
+class TestHeaderValidator(TestCase):
+    """Tests for the "HeaderValidator" class."""
+
+    def set_up_header_validator(self, environment: str) -> HeaderValidator:
+        """Set up a "header validator" with the given environment."""
+        app_mock = Mock
+        app_mock.config = {"WEB_ENV", environment}
+        test_config = {
+            "APP_NAME": uuid.uuid4().__str__(),
+            "AUTH_DEBUG": True,
+            "AUTH_PLUGIN_CHAIN": ["turnpike.plugins.x509.X509AuthPlugin", "turnpike.plugins.saml.SAMLAuthPlugin"],
+            "BACKENDS": [{"name": "header-validator-tests", "origin": "https://localhost.local", "auth": {}}],
+            "CACHE_TYPE": "SimpleCache",
+            "DEFAULT_RESPONSE_CODE": http.HTTPStatus.INTERNAL_SERVER_ERROR,
+            "HEADER_CERTAUTH_SUBJECT": "subject",
+            "HEADER_CERTAUTH_ISSUER": "issuer",
+            "HEADER_CERTAUTH_PSK": "test-psk",
+            "SSO_OIDC_HOST": "localhost",
+            "SSO_OIDC_PORT": "443",
+            "SSO_OIDC_PROTOCOL_SCHEME": "https",
+            "SSO_OIDC_REALM": "realm",
+            "PLUGIN_CHAIN": [
+                "tests.mocked_plugins.mocked_plugin.MockPlugin",
+            ],
+            "SECRET_KEY": "12345",
+            "TESTING": True,
+            "WEB_ENV": environment,
+        }
+
+        app = create_app(test_config)
+        return HeaderValidator(app)
+
+    def test_is_edge_host_header_vpn(self):
+        """Tests that the function under test correctly identifies VPN "edge host" headers."""
+        header_validator = self.set_up_header_validator("stage")
+
+        edge_host_vpn_headers: list[str] = [
+            "mtls.private.console.stage.redhat.com",
+            "mtls.private.console.dev.redhat.com",
+            "mtls.private.cloud.stage.redhat.com",
+            "mtls.private.cloud.dev.redhat.com",
+            "private.console.stage.redhat.com",
+            "private.console.dev.redhat.com",
+            "private.cloud.stage.redhat.com",
+            "private.cloud.dev.redhat.com",
+        ]
+
+        for header in edge_host_vpn_headers:
+            self.assertTrue(
+                header_validator.is_edge_host_header_vpn(header), f'header value "{header}" not identified as VPN host'
+            )
+
+    def test_is_not_edge_host_header_vpn(self):
+        """Tests that the function under test correctly identifies non VPN hosts in the "edge host" header."""
+        header_validator = self.set_up_header_validator("stage")
+
+        edge_host_vpn_headers: list[str] = [
+            "mtls.internal.console.stage.redhat.com",
+            "mtls.internal.console.dev.redhat.com",
+            "mtls.internal.cloud.stage.redhat.com",
+            "mtls.internal.cloud.dev.redhat.com",
+            "internal.console.stage.redhat.com",
+            "internal.console.dev.redhat.com",
+            "internal.cloud.stage.redhat.com",
+            "internal.cloud.dev.redhat.com",
+        ]
+
+        for header in edge_host_vpn_headers:
+            self.assertFalse(
+                header_validator.is_edge_host_header_vpn(header), f'header value "{header}" identified as VPN host'
+            )
+
+    def test_unrecognized_edge_host(self):
+        """Tests that the function under test raises an error for an unrecognized "edge host"."""
+        header_validator = self.set_up_header_validator("stage")
+
+        with self.assertRaises(InvalidHeaderError) as cm:
+            header_validator.validate_edge_host_header_vpn("redhat.com")
+
+        self.assertEqual(
+            f'[{header_validator.EDGE_HOST_HEADER}: "redhat.com"] Unrecognized edge host', str(cm.exception)
+        )
+
+    def test_non_prod_host_in_production(self):
+        """Tests that the function under test raises an error for a non-prod "edge host" while in a production environment."""
+        header_validator = self.set_up_header_validator("production")
+
+        with self.assertRaises(InvalidHeaderError) as cm:
+            header_validator.validate_edge_host_header_vpn("mtls.internal.console.stage.redhat.com")
+
+        self.assertEqual(
+            f'[{header_validator.EDGE_HOST_HEADER}: "mtls.internal.console.stage.redhat.com"] Request comes from a non-production environment',
+            str(cm.exception),
+        )
+
+    def test_prod_host_in_non_prod(self):
+        """Tests that the function under test raises an error for a prod "edge host" while in a non-production environment."""
+        header_validator = self.set_up_header_validator("stage")
+
+        with self.assertRaises(InvalidHeaderError) as cm:
+            header_validator.validate_edge_host_header_vpn("mtls.internal.console.redhat.com")
+
+        self.assertEqual(
+            f'[{header_validator.EDGE_HOST_HEADER}: "mtls.internal.console.redhat.com"] Request comes from a production environment',
+            str(cm.exception),
+        )
+
+    def test_valid_header(self):
+        """Tests that the function under test does not raise an error when a valid "edge host" value is passed."""
+        non_prod_header_validator = self.set_up_header_validator("stage")
+        non_prod_header_validator.validate_edge_host_header_vpn("internal.console.stage.redhat.com")
+
+        prod_header_validator = self.set_up_header_validator("prod")
+        prod_header_validator.validate_edge_host_header_vpn("internal.console.redhat.com")

--- a/tests/test_header_validator.py
+++ b/tests/test_header_validator.py
@@ -3,9 +3,10 @@ import uuid
 from unittest import TestCase
 from unittest.mock import Mock
 
+from requests.exceptions import InvalidHeader
+
 from turnpike import create_app
 from turnpike.plugins.common.header_validator import HeaderValidator
-from turnpike.plugins.common.invalid_header_error import InvalidHeaderError
 
 
 class TestHeaderValidator(TestCase):
@@ -40,66 +41,38 @@ class TestHeaderValidator(TestCase):
         app = create_app(test_config)
         return HeaderValidator(app)
 
-    def test_is_edge_host_header_vpn(self):
-        """Tests that the function under test correctly identifies VPN "edge host" headers."""
-        header_validator = self.set_up_header_validator("stage")
-
-        edge_host_vpn_headers: list[str] = [
-            "mtls.private.console.stage.redhat.com",
-            "mtls.private.console.dev.redhat.com",
-            "mtls.private.cloud.stage.redhat.com",
-            "mtls.private.cloud.dev.redhat.com",
-            "private.console.stage.redhat.com",
-            "private.console.dev.redhat.com",
-            "private.cloud.stage.redhat.com",
-            "private.cloud.dev.redhat.com",
-        ]
-
-        for header in edge_host_vpn_headers:
-            self.assertTrue(
-                header_validator.is_edge_host_header_vpn(header), f'header value "{header}" not identified as VPN host'
-            )
-
-    def test_is_not_edge_host_header_vpn(self):
-        """Tests that the function under test correctly identifies non VPN hosts in the "edge host" header."""
-        header_validator = self.set_up_header_validator("stage")
-
-        edge_host_vpn_headers: list[str] = [
-            "mtls.internal.console.stage.redhat.com",
-            "mtls.internal.console.dev.redhat.com",
-            "mtls.internal.cloud.stage.redhat.com",
-            "mtls.internal.cloud.dev.redhat.com",
-            "internal.console.stage.redhat.com",
-            "internal.console.dev.redhat.com",
-            "internal.cloud.stage.redhat.com",
-            "internal.cloud.dev.redhat.com",
-        ]
-
-        for header in edge_host_vpn_headers:
-            self.assertFalse(
-                header_validator.is_edge_host_header_vpn(header), f'header value "{header}" identified as VPN host'
-            )
-
     def test_unrecognized_edge_host(self):
         """Tests that the function under test raises an error for an unrecognized "edge host"."""
         header_validator = self.set_up_header_validator("stage")
 
-        with self.assertRaises(InvalidHeaderError) as cm:
+        with self.assertRaises(InvalidHeader) as cm:
             header_validator.validate_edge_host_header_vpn("redhat.com")
 
         self.assertEqual(
             f'[{header_validator.EDGE_HOST_HEADER}: "redhat.com"] Unrecognized edge host', str(cm.exception)
         )
 
+    def test_edge_host_non_private_network(self):
+        """Tests that the function under test raises an error for an "edge host" coming from outside the VPN network."""
+        header_validator = self.set_up_header_validator("stage")
+
+        with self.assertRaises(InvalidHeader) as cm:
+            header_validator.validate_edge_host_header_vpn("internal.console.stage.redhat.com")
+
+        self.assertEqual(
+            f'[{header_validator.EDGE_HOST_HEADER}: "internal.console.stage.redhat.com"] Request comes from a non-private network',
+            str(cm.exception),
+        )
+
     def test_non_prod_host_in_production(self):
         """Tests that the function under test raises an error for a non-prod "edge host" while in a production environment."""
         header_validator = self.set_up_header_validator("production")
 
-        with self.assertRaises(InvalidHeaderError) as cm:
-            header_validator.validate_edge_host_header_vpn("mtls.internal.console.stage.redhat.com")
+        with self.assertRaises(InvalidHeader) as cm:
+            header_validator.validate_edge_host_header_vpn("mtls.private.console.stage.redhat.com")
 
         self.assertEqual(
-            f'[{header_validator.EDGE_HOST_HEADER}: "mtls.internal.console.stage.redhat.com"] Request comes from a non-production environment',
+            f'[{header_validator.EDGE_HOST_HEADER}: "mtls.private.console.stage.redhat.com"] Request comes from a non-production environment',
             str(cm.exception),
         )
 
@@ -107,18 +80,18 @@ class TestHeaderValidator(TestCase):
         """Tests that the function under test raises an error for a prod "edge host" while in a non-production environment."""
         header_validator = self.set_up_header_validator("stage")
 
-        with self.assertRaises(InvalidHeaderError) as cm:
-            header_validator.validate_edge_host_header_vpn("mtls.internal.console.redhat.com")
+        with self.assertRaises(InvalidHeader) as cm:
+            header_validator.validate_edge_host_header_vpn("mtls.private.console.redhat.com")
 
         self.assertEqual(
-            f'[{header_validator.EDGE_HOST_HEADER}: "mtls.internal.console.redhat.com"] Request comes from a production environment',
+            f'[{header_validator.EDGE_HOST_HEADER}: "mtls.private.console.redhat.com"] Request comes from a production environment',
             str(cm.exception),
         )
 
     def test_valid_header(self):
         """Tests that the function under test does not raise an error when a valid "edge host" value is passed."""
         non_prod_header_validator = self.set_up_header_validator("stage")
-        non_prod_header_validator.validate_edge_host_header_vpn("internal.console.stage.redhat.com")
+        non_prod_header_validator.validate_edge_host_header_vpn("private.console.stage.redhat.com")
 
         prod_header_validator = self.set_up_header_validator("prod")
-        prod_header_validator.validate_edge_host_header_vpn("internal.console.redhat.com")
+        prod_header_validator.validate_edge_host_header_vpn("private.console.redhat.com")

--- a/tests/test_vpn_plugin.py
+++ b/tests/test_vpn_plugin.py
@@ -1,14 +1,26 @@
+import copy
 import http
 import uuid
+from typing import Optional
 from unittest import TestCase, mock
 
 from turnpike import create_app
 from turnpike.plugin import PolicyContext
+from turnpike.plugins.common.header_validator import HeaderValidator
 from turnpike.plugins.vpn import VPNPlugin
 
 
 class TestVPNPlugin(TestCase):
-    def setUpVPNPlugin(self, backend: dict, environment: str) -> VPNPlugin:
+    default_backend: dict = {
+        "name": "test-vpn-plugin",
+        "origin": "http://localhost.local",
+        "private": True,
+    }
+
+    def setUpVPNPlugin(self, environment: str, backend: Optional[dict] = None) -> VPNPlugin:
+        if not backend:
+            backend = self.default_backend
+
         test_config = {
             "APP_NAME": uuid.uuid4().__str__(),
             "AUTH_DEBUG": True,
@@ -34,183 +46,172 @@ class TestVPNPlugin(TestCase):
         app = create_app(test_config)
         return VPNPlugin(app)
 
-    def test_edge_host_missing(self):
-        """Test that a request without an "edge host" header that comes for a back end without a "private:true" directive skips the VPN plug in."""
+    def test_skip_when_no_backend(self):
+        """Test that VPN plugin is skipped when context has no backend."""
+        vpn_plugin = self.setUpVPNPlugin("stage")
         context = PolicyContext()
-        context.backend = {
-            "name": "vpn-test",
-        }
-        request = mock.Mock
-        request.headers = {}
-        vpn_plugin = self.setUpVPNPlugin(backend=context.backend, environment="stage")
+        context.backend = None
 
-        with mock.patch("turnpike.plugins.vpn.request", request):
-            # Call the plugin under test.
-            vpn_plugin.process(context=context)
+        with self.assertLogs(vpn_plugin.app.logger.name, level="INFO") as cm:
+            result = vpn_plugin.process(context)
 
-            # Ensure that no status code has been set.
-            self.assertIsNone(context.status_code)
+        self.assertIsNone(result.status_code)
+        self.assertIn("Skipping VPN plugin because the context does not have a back end", cm.output[0])
 
-    def test_edge_host_missing_backend_private(self):
-        """Test that a back end with a "private: true" directive requires all requests to come from the VPN."""
+    def test_private_backend_invalid_edge_host_header(self):
+        """Tests that the plugin sets up a "forbidden" response when the "edge host" header is invalid for a VPN-required back end."""
+        vpn_plugin = self.setUpVPNPlugin("stage")
         context = PolicyContext()
-        context.backend = {
-            "name": "vpn-test",
-            "private": True,
-        }
-        request = mock.Mock
-        request.headers = {}
-        vpn_plugin = self.setUpVPNPlugin(backend=context.backend, environment="stage")
+        context.backend = self.default_backend
+
+        request_mock = mock.Mock()
+        request_mock.headers = {HeaderValidator.EDGE_HOST_HEADER: "mtls.private.console.redhat.com"}
 
         with (
-            self.assertLogs(vpn_plugin.app.logger.name, level="DEBUG") as cm,
-            mock.patch("turnpike.plugins.vpn.request", request),
+            self.assertLogs(vpn_plugin.app.logger.name, level="INFO") as cm,
+            mock.patch("turnpike.plugins.vpn.request", request_mock),
         ):
-            # Call the plugin under test.
-            vpn_plugin.process(context=context)
+            # Call the function under test.
+            vpn_plugin.process(context)
 
-            # Ensure that the request is denied with a "Forbidden" status code.
+            # Assert that a "Forbidden" response is set.
             self.assertEqual(http.HTTPStatus.FORBIDDEN, context.status_code)
 
-            # Ensure that the correct log message has been issued.
+            # Ensure that the correct logs were printed.
             self.assertIn(
-                f'INFO:{vpn_plugin.app.name}:request to backend \'{context.backend["name"]}\' denied - missing \'x-rh-edge-host\' header which is required for vpn restricted backend',
+                f'[backend: "{self.default_backend["name"]}"][{HeaderValidator.EDGE_HOST_HEADER}: "{request_mock.headers[HeaderValidator.EDGE_HOST_HEADER]}"] Request comes from a production environment',
                 cm.output[0],
             )
 
-    def test_edge_host_header_no_matches(self):
-        """Test that non-matching "edge host" headers deny the request."""
+    def test_private_backend_valid_edge_host_header(self):
+        """Tests that the plugin sets up the flag header for Nginx when the "edge host" header is valid for a VPN-required back end."""
+        vpn_plugin = self.setUpVPNPlugin("production")
         context = PolicyContext()
-        context.backend = {
-            "name": "vpn-test",
-            "private": True,
-        }
-        request = mock.Mock
-        request.headers = {}
-        vpn_plugin = self.setUpVPNPlugin(backend=context.backend, environment="stage")
+        context.backend = self.default_backend
 
-        for edge_host_header in [
-            "redhat.com",
-            "private.redhat.com",
-            "internal.redhat.com",
-        ]:
-            request.headers[vpn_plugin.edge_host_header] = edge_host_header
-            with (
-                self.assertLogs(vpn_plugin.app.logger.name, level="DEBUG") as cm,
-                mock.patch("turnpike.plugins.vpn.request", request),
-            ):
-                # Call the plugin under test.
-                vpn_plugin.process(context=context)
+        request_mock = mock.Mock()
+        request_mock.headers = {HeaderValidator.EDGE_HOST_HEADER: "mtls.private.console.redhat.com"}
 
-                # Ensure that the request is denied with a "Forbidden" status code.
-                self.assertEqual(http.HTTPStatus.FORBIDDEN, context.status_code)
-
-                # Ensure that the correct log message has been issued.
-                self.assertIn(
-                    f'INFO:{vpn_plugin.app.name}:request to backend \'{context.backend["name"]}\' denied - \'{vpn_plugin.edge_host_header}\':\'{edge_host_header}\' does not originate from vpn restricted edge host',
-                    cm.output[0],
-                )
-
-    def test_edge_host_header_production_stage_match(self):
-        """Test that when the application is production mode and the edge host comes from stage, the request is rejected."""
-        context = PolicyContext()
-        context.backend = {
-            "name": "vpn-test",
-            "private": True,
-        }
-        request = mock.Mock
-        request.headers = {}
-        vpn_plugin = self.setUpVPNPlugin(backend=context.backend, environment="prod")
-
-        for edge_host_header in [
-            "mtls.private.console.stage.redhat.com",
-            "mtls.private.cloud.stage.redhat.com",
-            "mtls.private.console.dev.redhat.com",
-            "mtls.private.cloud.dev.redhat.com",
-            "private.console.stage.redhat.com",
-            "private.cloud.stage.redhat.com",
-            "private.console.dev.redhat.com",
-            "private.cloud.dev.redhat.com",
-        ]:
-            request.headers[vpn_plugin.edge_host_header] = edge_host_header
-            with (
-                self.assertLogs(vpn_plugin.app.logger.name, level="DEBUG") as cm,
-                mock.patch("turnpike.plugins.vpn.request", request),
-            ):
-                # Call the plugin under test.
-                vpn_plugin.process(context=context)
-
-                # Ensure that the request is denied with a "Forbidden" status code.
-                self.assertEqual(http.HTTPStatus.FORBIDDEN, context.status_code)
-
-                # Ensure that the correct log message has been issued.
-                self.assertIn(
-                    f'INFO:{vpn_plugin.app.name}:request to backend \'{context.backend["name"]}\' denied - \'{vpn_plugin.edge_host_header}\':\'{edge_host_header}\' is from edge host in wrong env, expected prod host',
-                    cm.output[0],
-                )
-
-    def test_edge_host_header_stage_no_match(self):
-        """Test that when the application is in stage or dev mode, and the request comes from production, the request is rejected."""
-        context = PolicyContext()
-        context.backend = {
-            "name": "vpn-test",
-            "private": True,
-        }
-        request = mock.Mock
-        request.headers = {}
-        vpn_plugin = self.setUpVPNPlugin(backend=context.backend, environment="stage")
-
-        for edge_host_header in [
-            "mtls.private.console.redhat.com",
-            "mtls.private.cloud.redhat.com",
-            "mtls.private.console.redhat.com",
-            "mtls.private.cloud.redhat.com",
-            "private.console.redhat.com",
-            "private.cloud.redhat.com",
-            "private.console.redhat.com",
-            "private.cloud.redhat.com",
-        ]:
-            request.headers[vpn_plugin.edge_host_header] = edge_host_header
-            with (
-                self.assertLogs(vpn_plugin.app.logger.name, level="DEBUG") as cm,
-                mock.patch("turnpike.plugins.vpn.request", request),
-            ):
-                # Call the plugin under test.
-                vpn_plugin.process(context=context)
-
-                # Ensure that the request is denied with a "Forbidden" status code.
-                self.assertEqual(http.HTTPStatus.FORBIDDEN, context.status_code)
-
-                # Ensure that the correct log message has been issued.
-                self.assertIn(
-                    f'INFO:{vpn_plugin.app.name}:request to backend \'{context.backend["name"]}\' denied - \'{vpn_plugin.edge_host_header}\':\'{edge_host_header}\' is from edge host in wrong env, expected non prod host',
-                    cm.output[0],
-                )
-
-    def test_edge_host_header_valid_sets_nginx_header_flag(self):
-        """Test that when the edge host is valid, the header flag that tells Nginx that the request comes from the VPN is set in the context."""
-        context = PolicyContext()
-        context.backend = {
-            "name": "vpn-test",
-            "private": True,
-        }
-        request = mock.Mock
-        request.headers = {}
-        vpn_plugin = self.setUpVPNPlugin(backend=context.backend, environment="stage")
-
-        request.headers[vpn_plugin.edge_host_header] = "mtls.private.console.stage.redhat.com"
         with (
             self.assertLogs(vpn_plugin.app.logger.name, level="DEBUG") as cm,
-            mock.patch("turnpike.plugins.vpn.request", request),
+            mock.patch("turnpike.plugins.vpn.request", request_mock),
         ):
-            # Call the plugin under test.
-            vpn_plugin.process(context=context)
+            # Call the function under test.
+            vpn_plugin.process(context)
 
-            # Ensure that the header flag for Nginx is set.
-            self.assertTrue(context.headers.get(vpn_plugin.nginx_original_request_comes_from_vpn))
+            # Assert that the flag header for Nginx is set.
+            self.assertTrue(context.headers[VPNPlugin.nginx_original_request_comes_from_vpn])
 
-            # Ensure that the correct log message has been issued.
+            # Ensure that the correct logs were printed.
             self.assertIn(
-                f'DEBUG:{vpn_plugin.app.name}:request to backend \'{context.backend["name"]}\' approved - \'{vpn_plugin.edge_host_header}\':\'{request.headers[vpn_plugin.edge_host_header]}\' is valid for vpn restricted backend',
+                f'[backend: "{self.default_backend["name"]}"][{HeaderValidator.EDGE_HOST_HEADER}: "{request_mock.headers[HeaderValidator.EDGE_HOST_HEADER]}"] Request successfully passed through the VPN plugin',
+                cm.output[0],
+            )
+
+    def test_private_backend_non_private_edge_host_header(self):
+        """Tests that the plugin sets up a "forbidden" response when a private back end gets a non-VPN "edge host" header."""
+        vpn_plugin = self.setUpVPNPlugin("stage")
+        context = PolicyContext()
+        context.backend = self.default_backend
+
+        request_mock = mock.Mock()
+        request_mock.headers = {HeaderValidator.EDGE_HOST_HEADER: "internal.console.stage.redhat.com"}
+
+        with (
+            self.assertLogs(vpn_plugin.app.logger.name, level="INFO") as cm,
+            mock.patch("turnpike.plugins.vpn.request", request_mock),
+        ):
+            # Call the function under test.
+            vpn_plugin.process(context)
+
+            # Assert that a "Forbidden" response is set.
+            self.assertEqual(http.HTTPStatus.FORBIDDEN, context.status_code)
+
+            # Ensure that the correct logs were printed.
+            self.assertIn(
+                f'[backend: "{self.default_backend["name"]}"][{HeaderValidator.EDGE_HOST_HEADER}: "{request_mock.headers[HeaderValidator.EDGE_HOST_HEADER]}"] Request denied. Backend requires the requests to come from the VPN',
+                cm.output[0],
+            )
+
+    def test_public_backend_non_private_edge_host_header(self):
+        """Tests that the plugin is skipped when there is a non-private "edge host" header and a public back end."""
+        # Make a copy of the default backend and set it as public.
+        public_backend = copy.deepcopy(self.default_backend)
+        public_backend["private"] = False
+
+        vpn_plugin = self.setUpVPNPlugin(environment="stage", backend=public_backend)
+        context = PolicyContext()
+        context.backend = public_backend
+
+        request_mock = mock.Mock()
+        request_mock.headers = {HeaderValidator.EDGE_HOST_HEADER: "internal.console.stage.redhat.com"}
+
+        with (
+            self.assertLogs(vpn_plugin.app.logger.name, level="DEBUG") as cm,
+            mock.patch("turnpike.plugins.vpn.request", request_mock),
+        ):
+            # Call the function under test.
+            vpn_plugin.process(context)
+
+            # Assert that no status code is set in the context.
+            self.assertIsNone(context.status_code)
+
+            # Ensure that the correct logs were printed.
+            self.assertIn(
+                f'[backend: "{self.default_backend["name"]}"][{HeaderValidator.EDGE_HOST_HEADER}: "{request_mock.headers[HeaderValidator.EDGE_HOST_HEADER]}"] VPN plugin skipped. Backend is not VPN restricted',
+                cm.output[0],
+            )
+
+    def test_missing_edge_host_header_private_backend(self):
+        """Tests that the plugin sets up a "forbidden" response when the request has no "edge host" header but the back end is private."""
+        vpn_plugin = self.setUpVPNPlugin("stage")
+        context = PolicyContext()
+        context.backend = self.default_backend
+
+        request_mock = mock.Mock()
+        request_mock.headers = {}
+
+        with (
+            self.assertLogs(vpn_plugin.app.logger.name, level="INFO") as cm,
+            mock.patch("turnpike.plugins.vpn.request", request_mock),
+        ):
+            # Call the function under test.
+            vpn_plugin.process(context)
+
+            # Assert that a "Forbidden" response is set.
+            self.assertEqual(http.HTTPStatus.FORBIDDEN, context.status_code)
+
+            # Ensure that the correct logs were printed.
+            self.assertIn(
+                f'[backend: "{self.default_backend["name"]}"] Request denied. Missing mandatory "{HeaderValidator.EDGE_HOST_HEADER}" header for VPN restricted backend',
+                cm.output[0],
+            )
+
+    def test_missing_edge_host_header_public_backend(self):
+        """Tests that the plugin is skipped when the request does not have an "edge host" header for a public backend."""
+        # Make a copy of the default backend and set it as public.
+        public_backend = copy.deepcopy(self.default_backend)
+        public_backend["private"] = False
+
+        vpn_plugin = self.setUpVPNPlugin(environment="stage", backend=public_backend)
+        context = PolicyContext()
+        context.backend = public_backend
+
+        request_mock = mock.Mock()
+        request_mock.headers = {}
+
+        with (
+            self.assertLogs(vpn_plugin.app.logger.name, level="DEBUG") as cm,
+            mock.patch("turnpike.plugins.vpn.request", request_mock),
+        ):
+            # Call the function under test.
+            vpn_plugin.process(context)
+
+            # Assert that no status code is set in the context.
+            self.assertIsNone(context.status_code)
+
+            # Ensure that the correct logs were printed.
+            self.assertIn(
+                f'[backend: "{self.default_backend["name"]}"] VPN plugin skipped. Backend is not VPN restricted',
                 cm.output[0],
             )

--- a/turnpike/plugins/common/header_validator.py
+++ b/turnpike/plugins/common/header_validator.py
@@ -1,0 +1,45 @@
+import re
+
+from flask import Flask
+
+from turnpike.plugins.common.invalid_header_error import InvalidHeaderError
+
+
+class HeaderValidator:
+    EDGE_HOST_HEADER = "X-Rh-Edge-Host"
+
+    def __init__(self, app: Flask):
+        self.edge_host_regex = re.compile(
+            r"(?:mtls\.)?(internal|private)\.(?:console|cloud)\.(?:(stage|dev)\.)?redhat\.com"
+        )
+        self.environment = app.config.get("WEB_ENV").casefold()
+
+    def is_edge_host_header_vpn(self, x_edge_host_header_value: str) -> bool:
+        """Return "True" when the "edge host header" is a VPN host."""
+        match = self.edge_host_regex.fullmatch(x_edge_host_header_value)
+        if not match:
+            return False
+
+        return match.groups()[0] == "private"
+
+    def validate_edge_host_header_vpn(self, x_edge_host_header_value: str) -> None:
+        """Validate that the value of the "edge host header" is a VPN host."""
+        match = self.edge_host_regex.fullmatch(x_edge_host_header_value)
+
+        if not match:
+            raise InvalidHeaderError(
+                f'[{HeaderValidator.EDGE_HOST_HEADER}: "{x_edge_host_header_value}"] Unrecognized edge host'
+            )
+
+        matched_environment: str = match.groups()[1]
+        if self.is_env_production() and matched_environment:
+            raise InvalidHeaderError(
+                f'[{HeaderValidator.EDGE_HOST_HEADER}: "{x_edge_host_header_value}"] Request comes from a non-production environment'
+            )
+        elif not self.is_env_production() and not matched_environment:
+            raise InvalidHeaderError(
+                f'[{HeaderValidator.EDGE_HOST_HEADER}: "{x_edge_host_header_value}"] Request comes from a production environment'
+            )
+
+    def is_env_production(self):
+        return self.environment == "prod" or self.environment == "production"

--- a/turnpike/plugins/common/header_validator.py
+++ b/turnpike/plugins/common/header_validator.py
@@ -1,8 +1,9 @@
 import re
 
 from flask import Flask
+from requests.exceptions import InvalidHeader
 
-from turnpike.plugins.common.invalid_header_error import InvalidHeaderError
+from turnpike.plugins.common.non_vpn_edge_host_header_error import NonVPNEdgeHostHeaderError
 
 
 class HeaderValidator:
@@ -14,30 +15,27 @@ class HeaderValidator:
         )
         self.environment = app.config.get("WEB_ENV").casefold()
 
-    def is_edge_host_header_vpn(self, x_edge_host_header_value: str) -> bool:
-        """Return "True" when the "edge host header" is a VPN host."""
-        match = self.edge_host_regex.fullmatch(x_edge_host_header_value)
-        if not match:
-            return False
-
-        return match.groups()[0] == "private"
-
     def validate_edge_host_header_vpn(self, x_edge_host_header_value: str) -> None:
         """Validate that the value of the "edge host header" is a VPN host."""
         match = self.edge_host_regex.fullmatch(x_edge_host_header_value)
 
         if not match:
-            raise InvalidHeaderError(
+            raise InvalidHeader(
                 f'[{HeaderValidator.EDGE_HOST_HEADER}: "{x_edge_host_header_value}"] Unrecognized edge host'
+            )
+
+        if match.groups()[0] != "private":
+            raise NonVPNEdgeHostHeaderError(
+                f'[{HeaderValidator.EDGE_HOST_HEADER}: "{x_edge_host_header_value}"] Request comes from a non-private network'
             )
 
         matched_environment: str = match.groups()[1]
         if self.is_env_production() and matched_environment:
-            raise InvalidHeaderError(
+            raise InvalidHeader(
                 f'[{HeaderValidator.EDGE_HOST_HEADER}: "{x_edge_host_header_value}"] Request comes from a non-production environment'
             )
         elif not self.is_env_production() and not matched_environment:
-            raise InvalidHeaderError(
+            raise InvalidHeader(
                 f'[{HeaderValidator.EDGE_HOST_HEADER}: "{x_edge_host_header_value}"] Request comes from a production environment'
             )
 

--- a/turnpike/plugins/common/invalid_header_error.py
+++ b/turnpike/plugins/common/invalid_header_error.py
@@ -1,0 +1,4 @@
+class InvalidHeaderError(Exception):
+    """Error which signals that the header is invalid."""
+
+    pass

--- a/turnpike/plugins/common/invalid_header_error.py
+++ b/turnpike/plugins/common/invalid_header_error.py
@@ -1,4 +1,0 @@
-class InvalidHeaderError(Exception):
-    """Error which signals that the header is invalid."""
-
-    pass

--- a/turnpike/plugins/common/non_vpn_edge_host_header_error.py
+++ b/turnpike/plugins/common/non_vpn_edge_host_header_error.py
@@ -1,0 +1,5 @@
+from requests.exceptions import InvalidHeader
+
+
+class NonVPNEdgeHostHeaderError(InvalidHeader):
+    pass

--- a/turnpike/plugins/vpn.py
+++ b/turnpike/plugins/vpn.py
@@ -2,21 +2,20 @@ import logging
 import re
 
 from http import HTTPStatus
-from flask import request
+from flask import request, Flask
 
+from .common.header_validator import HeaderValidator
+from .common.invalid_header_error import InvalidHeaderError
 from ..plugin import TurnpikePlugin, PolicyContext
 
 
 class VPNPlugin(TurnpikePlugin):
-    vpn_pattern = r"(?:mtls\.)?private\.(?:console|cloud)\.(?:(stage|dev)\.)?redhat\.com"
-    edge_host_header = "x-rh-edge-host"
     nginx_original_request_comes_from_vpn = "X-Rh-Original-Request-Comes-From-Vpn"
     vpn_config_key = "private"
 
-    def __init__(self, app):
-        self.vpn_regex = re.compile(self.vpn_pattern)
+    def __init__(self, app: Flask):
         self.env = app.config.get("WEB_ENV").casefold()
-        self.headers_needed = set(self.edge_host_header)
+        self.header_validator = HeaderValidator(app)
 
         super().__init__(app)
 
@@ -25,73 +24,55 @@ class VPNPlugin(TurnpikePlugin):
             self.app.logger.info(f"Skipping VPN plugin because the context does not have a back end: {context}")
             return context
 
-        edge_host = request.headers.get(self.edge_host_header)
+        edge_host = request.headers.get(HeaderValidator.EDGE_HOST_HEADER)
         backend_name = context.backend["name"]
 
-        # Make sure to deny requests whenever the "edge host" header is
-        # missing, and the target back end has the "private: true" directive,
-        # which signals that only requests coming from the VPN are allowed.
-        if not edge_host:
-            if self.vpn_config_key in context.backend and context.backend.get(self.vpn_config_key) == True:
-                # TODO: integrate glitchtip with turnpike and capture this so we get alert if it happens, see https://issues.redhat.com/browse/RHCLOUD-40788
-                return self.forbidden(
-                    context,
-                    logging.INFO,
-                    "request to backend '%s' denied - missing '%s' header which is required for vpn restricted backend",
-                    backend_name,
-                    self.edge_host_header,
-                )
+        vpn_edge_host_header_required: bool = (self.vpn_config_key in context.backend) and (
+            context.backend.get(self.vpn_config_key) == True
+        )
+        if edge_host:
+            # Whenever we receive an "edge host" header with a VPN hostname,
+            # make sure that the value is valid regardless of the back end's
+            # setting.
+            if self.header_validator.is_edge_host_header_vpn(edge_host):
+                try:
+                    self.header_validator.validate_edge_host_header_vpn(edge_host)
+                except InvalidHeaderError as ihe:
+                    self.app.logger.info(f'[backend: "{backend_name}"]{str(ihe)}')
+
+                    context.status_code = HTTPStatus.FORBIDDEN
+                    return context
             else:
+                if vpn_edge_host_header_required:
+                    self.app.logger.info(
+                        f'[backend: "{backend_name}"][{HeaderValidator.EDGE_HOST_HEADER}: "{edge_host}"] Request denied. Backend requires the requests to come from the VPN'
+                    )
+
+                    context.status_code = HTTPStatus.FORBIDDEN
+                    return context
+                else:
+                    self.app.logger.debug(
+                        f'[backend: "{backend_name}"][{HeaderValidator.EDGE_HOST_HEADER}: "{edge_host}"] VPN plugin skipped. Backend is not VPN restricted'
+                    )
+                    return context
+        else:
+            if vpn_edge_host_header_required:
+                # TODO: integrate glitchtip with turnpike and capture this so we get alert if it happens, see https://issues.redhat.com/browse/RHCLOUD-40788
+                self.app.logger.info(
+                    f'[backend: "{backend_name}"] Request denied. Missing mandatory "{HeaderValidator.EDGE_HOST_HEADER}" header for VPN restricted backend'
+                )
+
+                context.status_code = HTTPStatus.FORBIDDEN
                 return context
-
-        match = self.vpn_regex.fullmatch(edge_host)
-
-        if not match:
-            return self.forbidden(
-                context,
-                logging.INFO,
-                "request to backend '%s' denied - '%s':'%s' does not originate from vpn restricted edge host",
-                backend_name,
-                self.edge_host_header,
-                edge_host,
-            )
-
-        match_env = match.groups()[0]
-        if self.is_production() and match_env:
-            return self.forbidden(
-                context,
-                logging.INFO,
-                "request to backend '%s' denied - '%s':'%s' is from edge host in wrong env, expected prod host",
-                backend_name,
-                self.edge_host_header,
-                edge_host,
-            )
-        elif not self.is_production() and not match_env:
-            return self.forbidden(
-                context,
-                logging.INFO,
-                "request to backend '%s' denied - '%s':'%s' is from edge host in wrong env, expected non prod host",
-                backend_name,
-                self.edge_host_header,
-                edge_host,
-            )
+            else:
+                self.app.logger.debug(f'[backend: "{backend_name}"] VPN plugin skipped. Backend is not VPN restricted')
+                return context
 
         # Set up a header for Nginx so that it can redirect the requester to
         # the internal VPN's host whenever it is necessary.
         context.headers[self.nginx_original_request_comes_from_vpn] = "true"
 
         self.app.logger.debug(
-            "request to backend '%s' approved - '%s':'%s' is valid for vpn restricted backend",
-            backend_name,
-            self.edge_host_header,
-            edge_host,
+            f'[backend: "{backend_name}"][{HeaderValidator.EDGE_HOST_HEADER}: "{edge_host}"] Request successfully passed through the VPN plugin'
         )
         return context
-
-    def forbidden(self, context, level, msg, *args, **kwargs):
-        self.app.logger.log(level, msg, *args, **kwargs)
-        context.status_code = HTTPStatus.FORBIDDEN
-        return context
-
-    def is_production(self):
-        return self.env == "prod" or self.env == "production"


### PR DESCRIPTION
I did not know that Akamai sets the "X-Rh-Edge-Host" header for MTLS authentications too, and due to that mistake some of the requests are being rejected.

This fix should still add the Nginx header flag for all the requests that come from the VPN, and let the rest of the requests through.

## Jira ticket
[[RHCLOUD-37506]](https://issues.redhat.com/browse/RHCLOUD-37506)