### PR TITLE
RHCLOUD-37506 | fix: imports

### DIFF
--- a/turnpike/config.py
+++ b/turnpike/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+
 import redis
 import yaml
 from redis import Redis

--- a/turnpike/plugins/saml.py
+++ b/turnpike/plugins/saml.py
@@ -1,7 +1,4 @@
-from flask import current_app, request, session, url_for
-
-from ..plugin import TurnpikeAuthPlugin
-from flask import current_app, request, session, url_for
+from flask import current_app, session
 
 from ..plugin import TurnpikeAuthPlugin
 

--- a/turnpike/views/saml/acs_view.py
+++ b/turnpike/views/saml/acs_view.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 
-from flask import views, session, request, redirect, current_app, make_response
+from flask import session, request, redirect, current_app, make_response
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
 from turnpike.views.saml.generic_saml_view import GenericSAMLView

--- a/turnpike/views/saml/login_view.py
+++ b/turnpike/views/saml/login_view.py
@@ -1,4 +1,4 @@
-from flask import views, redirect, request
+from flask import redirect, request
 
 from turnpike.views.saml.generic_saml_view import GenericSAMLView
 from turnpike.views.saml.saml_context import SAMLContext

--- a/turnpike/views/saml/metadata_view.py
+++ b/turnpike/views/saml/metadata_view.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 
-from flask import views, make_response
+from flask import make_response
 
 from turnpike.views.saml.generic_saml_view import GenericSAMLView
 from turnpike.views.saml.saml_context import SAMLContext

--- a/turnpike/views/saml/saml_context.py
+++ b/turnpike/views/saml/saml_context.py
@@ -1,9 +1,8 @@
 from urllib.parse import urlparse
 
-from flask import request, session, current_app
+from flask import request, current_app
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 
-from turnpike.plugins.vpn import VPNPlugin
 from turnpike.views.saml.saml_settings_type import SAMLSettingsType
 
 

--- a/turnpike/views/saml/sls_view.py
+++ b/turnpike/views/saml/sls_view.py
@@ -1,7 +1,7 @@
 from http import HTTPStatus
+from typing import Optional
 
-from black.brackets import Optional
-from flask import views, session, redirect, make_response
+from flask import session, redirect, make_response
 
 from turnpike.views.saml.generic_saml_view import GenericSAMLView
 from turnpike.views.saml.saml_context import SAMLContext


### PR DESCRIPTION
The imports are causing the pods to crashloop because I incorrectly added the wrong import for the "Optional" class.

## Jira ticket
[[RHCLOUD-37506]](https://issues.redhat.com/browse/RHCLOUD-37506)