### PR TITLE
RHCLOUD-37506 | fix: redirections to the private network are not working

### DIFF
--- a/nginx/configuration_builder/templates/api_gateway.conf.j2
+++ b/nginx/configuration_builder/templates/api_gateway.conf.j2
@@ -60,7 +60,7 @@ server {
         # In the case that the request comes from the "private" network,
         # override the settings so that the redirect points to the "private"
         # SAML endpoints instead.
-        if ($host ~ private) {
+        if ($http_x_rh_edge_host ~ private) {
             set $redirect_hostname  {{ PRIVATE_HOSTNAME }};
             set $saml_type          'private';
         }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,10 +13,17 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for" '
-                      '"$host" ($http_x_forwarded_host)';
+    log_format  main  '[local_time: "$time_local"]'
+                      '[remote_address: "$remote_addr"]'
+                      '[request: "$request"]'
+                      '[response_status: "$status"]'
+                      ' — Headers: '
+                      '[Host: "$host"]'
+                      '[Referer: "$http_referer"]'
+                      '[User-Agent: "$http_user_agent"]'
+                      '[X-Edge-Host: "$http_x_rh_edge_host"]'
+                      '[X-Forwarded-For: "$http_x_forwarded_for"]'
+                      '[X-Forwarded-Host: "$http_x_forwarded_host"]';
 
     access_log  /dev/stderr  main;
 


### PR DESCRIPTION
We were interested in the value of the "X-Edge-Host" header, which is
the one that we use in the VPN plug in too to determine to which host we
need to redirect the user.

## Jira ticket
[[RHCLOUD-37506]](https://issues.redhat.com/browse/RHCLOUD-37506)