### PR TITLE
Add AI-assisted development documentation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# See https://docs.coderabbit.ai/reference/configuration for all fields and default values
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - "docs/*-guidelines.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+Turnpike is a Flask-based API gateway that acts as an nginx `auth_request` subrequest handler for Red Hat Insights. It evaluates authentication and authorization policies (SAML, OIDC/JWT, mTLS/X.509, Basic Auth via registry, VPN/source-IP) via a plugin chain, returning status codes that nginx uses to allow or deny proxied requests.
+
+## Guideline Documents
+
+Detailed domain-specific rules live in these files -- read them before making changes in their areas:
+
+- `docs/security-guidelines.md` -- Plugin chain invariants, eval-based predicates, secret management, header trust boundaries
+- `docs/performance-guidelines.md` -- Caching patterns (JWKS, registry), Redis usage, timeout conventions, Gunicorn/nginx tuning
+- `docs/error-handling-guidelines.md` -- Status code semantics (200/401/403/500), plugin error-flow, startup validation, logging levels
+- `docs/api-contracts-guidelines.md` -- Endpoint inventory, request/response headers, backend YAML schema, route matching rules
+- `docs/testing-guidelines.md` -- Test framework (unittest.TestCase), app config pattern, mocking conventions, coverage expectations
+- `docs/integration-guidelines.md` -- Outbound HTTP conventions, mTLS client certs, OIDC/JWKS fetch, nginx config builder startup
+
+## Project Structure
+
+```
+turnpike/                  # Flask application package
+  __init__.py              # create_app() factory, OIDC validation, blueprint registration
+  config.py                # All env-var-driven configuration (loaded at import time)
+  plugin.py                # PolicyContext, TurnpikePlugin, TurnpikeAuthPlugin base classes
+  cache.py                 # Flask-Caching instance (Redis in prod, SimpleCache in tests)
+  metrics.py               # Prometheus counter definition
+  views/views.py           # /auth/, /identity/, /session/, /_nginx_config/ handlers
+  views/saml/              # SAML blueprint views (login, acs, sls, metadata, mock)
+  plugins/                 # Plugin implementations
+    auth.py                # AuthPlugin -- orchestrates AUTH_PLUGIN_CHAIN
+    vpn.py                 # VPN/edge-host enforcement
+    source_ip.py           # Source IP CIDR allowlist
+    rh_identity.py         # X-RH-Identity header construction
+    oidc/oidc.py           # JWT/OIDC authentication
+    registry.py            # Basic Auth against external registry service
+    saml.py                # SAML session-based authentication
+    x509.py                # mTLS/X.509 certificate authentication
+    common/                # Shared utilities (HeaderValidator, AllowedNetworks)
+nginx/                     # Nginx container
+  configuration_builder/   # build_config.py -- generates nginx locations from backends YAML + Jinja2
+  conf.d/                  # Static nginx config
+tests/                     # unittest.TestCase-based tests; one file per module
+  backends/                # YAML fixtures (valid and invalid backend configs)
+  mocked_plugins/          # MockPlugin for test inspection
+templates/                 # OpenShift deployment templates (web.yml, nginx.yml, prometheus-nginx.yml)
+.tekton/                   # Konflux/Tekton CI pipeline definitions
+scripts/                   # Dev convenience scripts
+```
+
+## Code Style and Formatting
+
+- **Python 3.11** is the target runtime.
+- **black** enforces formatting: line length 119, target py311 (`black -l 119 -t py311`).
+- **mypy** runs with `ignore_missing_imports = True` (see `mypy.ini`).
+- **Pre-commit hooks**: black, trailing-whitespace, end-of-file-fixer, debug-statements, mypy. Install with `pre-commit install`.
+- Dependencies: **Pipfile/Pipfile.lock** (pipenv). Most packages are pinned exactly. Container build uses `micropipenv`.
+
+## Architectural Patterns
+
+- **Two-container model**: nginx (reverse proxy + TLS termination) and Flask (policy decisions only). Flask never proxies traffic.
+- **Plugin chain via dynamic import**: `PLUGIN_CHAIN` and `AUTH_PLUGIN_CHAIN` are dotted Python class paths in `config.py`, imported at startup. Each must subclass `TurnpikePlugin` or `TurnpikeAuthPlugin`.
+- **PolicyContext is the shared state object**: all plugins receive and return the same context. `context.status_code` short-circuits the outer chain; `context.auth` stops only the inner auth chain.
+- **Config is module-level with fail-fast**: `config.py` executes at import time. Missing required env vars raise `ValueError` immediately.
+- **Nginx config is generated at container startup**: `build_config.py` polls `/_nginx_config/` and renders Jinja2 templates. Plugin `headers_needed`/`headers_to_forward` declarations drive nginx config automatically.
+- **Dual SAML configuration**: two independent IdP configs (internal vs. private) served under `/saml/internal/` and `/saml/private/` blueprints.
+
+## CI/CD and Branching
+
+- **Default branch**: `master`.
+- **Konflux/Tekton pipelines** build three images: `turnpike-web`, `turnpike-nginx`, `turnpike-nginx-prometheus`.
+- **PR checks**: `turnpike-web` runs black + pytest via `konflux-pr-check.sh`. Nginx pipelines build only.
+- **GitHub Actions**: pre-commit, JSON/YAML validation, security scanning (Grype + Syft SBOM), bot PR labeling.
+- **Dependency bumps** use `chore(deps):` commit prefix (MintMaker/Dependabot).
+
+## Common Pitfalls
+
+1. **`config.py` runs at import time** -- new required env vars crash on import, including test collection. Tests must pass a self-contained dict to `create_app(test_config)`.
+2. **Tests must run from the repo root** -- nginx builder tests use relative `sys.path` appends.
+3. **Auth predicates use `eval()`** -- SAML, X.509, and registry rules are Python expressions from YAML config. These are trusted configuration, never user-derived input.
+4. **OIDC issuer vs host URL** -- `issuer` (for JWT `iss` validation) excludes port; `host` (for HTTP calls) includes it.
+5. **No timeout on OIDC HTTP calls** -- known gap; all new outbound calls must include explicit `timeout=`.
+6. **`/auth/` endpoint returns empty bodies** -- nginx ignores `auth_request` response bodies. Never put error details in `policy_view` responses.
+7. **Backend list is scanned linearly** -- route matching and name lookup iterate all backends. Fine at current scale (tens of backends).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+@AGENTS.md
+
+## Commands
+
+```bash
+# Install dependencies
+pipenv install --dev
+
+# Install pre-commit hooks (run once after clone)
+pre-commit install
+
+# Run tests (from repo root)
+pytest tests/
+
+# Run black formatter check
+black --check -l 119 -t py311 .
+
+# Run mypy
+mypy turnpike/
+
+# Start dev server (Flask reloader)
+FLASK_ENV=development ./run-server.sh
+```
+
+## Pre-commit Hooks
+
+Hooks run automatically on `git commit`: black (line length 119, py311), trailing-whitespace, end-of-file-fixer, debug-statements, mypy. CI re-runs them via GitHub Actions on every PR. Fix all hook failures before pushing.
+
+## CI (Konflux PR Check)
+
+`konflux-pr-check.sh` is what runs in the Konflux/Tekton `turnpike-web` pipeline: it installs deps, runs `black --check`, then `pytest`. Tests must pass from the repo root — nginx builder tests rely on relative `sys.path` appends.
+
+## Notes for Claude Code
+
+- Run `pytest tests/` from the repo root, not a subdirectory.
+- `config.py` executes at import time; new required env vars will break test collection unless passed via `create_app(test_config)`.
+- Default branch is `master`, not `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Turnpike
+
+## Getting started
+
+```bash
+git clone https://github.com/RedHatInsights/turnpike.git
+cd turnpike
+pipenv install --dev
+pre-commit install
+```
+
+## Development workflow
+
+1. Branch from `master`.
+2. Make your changes.
+3. Run tests: `pytest tests/` (must run from the repo root).
+4. Fix any formatting issues: `black -l 119 -t py311 .`
+5. Fix any type errors: `mypy turnpike/`
+6. Pre-commit hooks run automatically on `git commit` and enforce all of the above.
+7. Open a pull request against `master`.
+
+## CI checks
+
+The `turnpike-web` Konflux pipeline runs on every PR and must pass before merging:
+- `black --check` (line length 119, Python 3.11 target)
+- `pytest tests/`
+
+GitHub Actions additionally run pre-commit hooks, JSON/YAML validation, and a security image scan (Anchore Grype + Syft SBOM) on pushes to `master`.
+
+## Adding a backend route
+
+Adding or modifying a backend route does **not** require a code change. Routes are defined in the `turnpike-routes` ConfigMap in app-interface. See the backend YAML schema in `docs/api-contracts-guidelines.md` and the README for examples.
+
+## Writing a new plugin
+
+Subclass `TurnpikePlugin` (from `turnpike.plugin`) for general policy plugins, or `TurnpikeAuthPlugin` for authentication plugins. Add your class's dotted path to `PLUGIN_CHAIN` or `AUTH_PLUGIN_CHAIN` in the deployment config.
+
+See `docs/testing-guidelines.md` for how to write tests for new plugins, and `docs/security-guidelines.md` for the plugin chain security invariants to follow.
+
+## Dependency management
+
+Dependencies are managed with **pipenv** (`Pipfile` / `Pipfile.lock`). Pin new dependencies to exact versions in `Pipfile`. After updating, run `pipenv lock` and commit both files.
+
+Automated dependency updates are handled by MintMaker and Dependabot. Their PRs are labeled `bot` automatically and use the commit prefix `chore(deps):` — do not merge them manually unless CI is failing.
+
+## Commit style
+
+- Keep commit messages concise and in the imperative mood.
+- Dependency bumps: `chore(deps): update <package> to <version>`
+- For everything else, describe what changed and why (the "why" matters more than the "what").
+
+## Further reading
+
+- [AGENTS.md](AGENTS.md) — Architecture, conventions, and common pitfalls for this repo
+- [docs/testing-guidelines.md](docs/testing-guidelines.md) — Detailed testing conventions
+- [docs/security-guidelines.md](docs/security-guidelines.md) — Security rules for plugin development

--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ See the docstrings on those classes for more details.
 You can check out the [service documentation][docs] in the `docs/` folder for more info.
 Such as how to access turnpike, acquire certs, etc.
 
+For AI-assisted development, see:
+
+- [AGENTS.md](AGENTS.md) — Agent onboarding: architecture, conventions, common pitfalls
+- [docs/security-guidelines.md](docs/security-guidelines.md) — Plugin chain invariants, secret management, header trust
+- [docs/performance-guidelines.md](docs/performance-guidelines.md) — Caching, timeouts, Redis patterns
+- [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) — Status codes, logging, startup validation
+- [docs/api-contracts-guidelines.md](docs/api-contracts-guidelines.md) — Endpoint inventory, headers, backend YAML schema
+- [docs/testing-guidelines.md](docs/testing-guidelines.md) — Test patterns, mocking conventions, CI
+- [docs/integration-guidelines.md](docs/integration-guidelines.md) — Outbound HTTP, OIDC/JWKS, nginx interop
+
 
 ## Testing
 To run local unit tests:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to configure manually or understand what the script does, read on.
 
 ### Nginx Configuration
 
-In `services/nginx`, create the following files:
+In `nginx/`, create the following files:
 
 1. `certs/cert.pem` - The PEM encoded certificate for Nginx (can be the same as the web cert)
 2. `certs/key.pem` - The PEM encoded certificate for Nginx (can be the same as the web key)
@@ -56,7 +56,7 @@ As with any SAML SP configuration, you will need:
 2. The SSL certificate for your SAML Identity Provider (IdP)
 3. The configuration of your Identity Provider as exposed by their IdP metadata endpoint.
 
-Then in your copy of the Turnpike code, in `/saml` create the following files:
+Then in your copy of the Turnpike code, in `./saml` create the following files:
 
 1. `settings.json`- The metadata settings for the IdP and SP (an [example][settings-example])
 2. `advanced_settings.json` - Advanced SAML settings for the IdP and SP (an [example][adv-settings-example])
@@ -72,7 +72,7 @@ If you're looking to simply demo Turnpike or aren't ready to integrate with your
 SAML test integration services available at https://samltest.id
 
 You will also need to generate a TLS certificate for the hostname you're going to use to access your running development
-environment. In `/nginx/certs`, name the certificate as `cert.pem` and the private key as `key.pem`.
+environment. In `nginx/certs/`, name the certificate as `cert.pem` and the private key as `key.pem`.
 
 If you are deploying Turnpike in Kubernetes or OpenShift, you should mount these configuration files using a
 combination of ConfigMap and Secret resources mounted into your running pods.
@@ -124,9 +124,9 @@ The substring matching of `route` and the rewriting to `origin` are the same as 
 rules.
 
 If a route has a key `auth`, then it will require authentication. *If the `auth` key is missing, the default is to forbid
-access unless the route resides under `/public/`* [(see best practices)][route-best-practice]. The `auth` key's value should be a set of key/value
+access unless the route resides under `/public/`* or the route is VPN restricted [(see best practices)][route-best-practice]. The `auth` key's value should be a set of key/value
 pairs representing supported authentication schemes and corresponding authorization rules. At this time, the only
-supported authentication schemes are `saml`, `x509`.
+supported authentication schemes are `saml`, `x509`, `oidc`, and `registry`.
 
 The value associated with `saml` should be a Python expression that evaluates to `True` or `False`. The only variable
 in the expression is a dictionary `user` which contains the SAML assertion for the requesting user. If the assertion
@@ -206,6 +206,7 @@ Such as how to access turnpike, acquire certs, etc.
 For AI-assisted development, see:
 
 - [AGENTS.md](AGENTS.md) — Agent onboarding: architecture, conventions, common pitfalls
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — Design decisions and architectural rationale
 - [docs/security-guidelines.md](docs/security-guidelines.md) — Plugin chain invariants, secret management, header trust
 - [docs/performance-guidelines.md](docs/performance-guidelines.md) — Caching, timeouts, Redis patterns
 - [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) — Status codes, logging, startup validation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,57 @@
+# Architecture
+
+This document explains the **why** behind Turnpike's design decisions. For operational rules and conventions, see the guideline documents referenced in AGENTS.md.
+
+## Why nginx auth_request
+
+Turnpike uses nginx's `auth_request` directive to delegate authentication decisions to a Flask sidecar rather than embedding auth logic in nginx itself or running Flask as a full reverse proxy.
+
+The key insight is **separation of the data plane from the policy plane**. Nginx handles TLS termination, connection management, buffering, timeouts, and proxying — things it is extremely good at. Flask handles the policy decision — evaluating SAML sessions, verifying JWTs, checking mTLS headers, querying external registries — things that require complex logic, shared state (Redis sessions), and dynamic configuration. The `/auth/` subrequest carries no request body (`proxy_pass_request_body off`); the policy service sees only headers and returns only a status code with optional response headers.
+
+The trade-off is startup coupling: nginx must wait for Flask to be ready before generating its config. `build_config.py` polls `/_nginx_config/` in a retry loop until Flask responds — the only retry pattern in the codebase.
+
+## Why two containers (nginx + Flask)
+
+Nginx and Flask are separate container images deployed as separate Kubernetes Deployments. Nginx needs minimal CPU/memory and handles many concurrent connections. Flask needs more CPU for cryptographic operations (JWT verification, SAML processing) but handles relatively few concurrent requests (4 Gunicorn sync workers). Separate Deployments let each scale independently.
+
+The cost is network latency on the subrequest path — every authenticated request incurs an HTTP round-trip from nginx to Flask. This is acceptable because the policy service is in the same cluster (origin domain restriction enforces `.svc.cluster.local`).
+
+## Why the plugin chain is dynamically loaded
+
+`PLUGIN_CHAIN` and `AUTH_PLUGIN_CHAIN` are dotted Python class paths resolved via `importlib` at startup. Turnpike runs in multiple environments (stage, production, development) with different authentication requirements. Rather than maintaining environment-specific forks, the plugin chain is reconfigured per deployment via config values. A deployment can remove VPN enforcement or add a custom plugin without modifying source code.
+
+The two-level chain design (outer `PLUGIN_CHAIN` with `AuthPlugin` orchestrating `AUTH_PLUGIN_CHAIN`) exists because authentication and policy enforcement are distinct concerns. VPN restriction and source-IP filtering are network-level checks that apply regardless of auth method. The auth sub-chain is "first match wins"; the outer chain is "run all unless short-circuited."
+
+## Why PolicyContext carries shared state
+
+Plugins receive a mutable `PolicyContext` rather than reading request headers directly, for three reasons:
+
+1. **Short-circuit signaling**: Setting `context.status_code` stops the chain. This is the only early-termination mechanism.
+2. **Cross-plugin data flow**: `RHIdentityPlugin` reads `context.auth` (set by whichever auth plugin succeeded) to build the `X-RH-Identity` header.
+3. **Testability**: Tests construct a `PolicyContext`, pass it through a plugin, and inspect the result without a full HTTP request/response cycle.
+
+## Why two SAML configurations (internal vs. private)
+
+Turnpike serves two network audiences that authenticate against different SAML Identity Providers:
+
+- **Internal** (`internal.console.redhat.com`): Red Hat corporate network, internal SSO.
+- **Private** (`private.console.redhat.com`): VPN-only, separate SSO instance.
+
+These are genuinely different IdPs. They cannot share a single SAML SP configuration because python3-saml validates that the IdP response's `Destination` matches the SP's configured hostname. The `@error401` nginx handler inspects `X-Rh-Edge-Host` to redirect unauthenticated users to the correct SAML login URL.
+
+## Deployment context (OpenShift/Kubernetes)
+
+- **ConfigMaps**: Backend route definitions, SAML IdP settings. Annotated with `qontract.recycle: "true"` so changes trigger pod restarts.
+- **Secrets**: Flask `SECRET_KEY`, SAML SP cert/key, CDN pre-shared key (primary + alt for rotation), Redis endpoint, mTLS client cert for registry service.
+
+The backends YAML (`/etc/turnpike/backends.yml`) is the single source of truth for routing — injected into both containers. Adding a backend is a ConfigMap change via app-interface merge request; no code change required.
+
+## Known design gaps and constraints
+
+**OIDC HTTP calls have no timeout.** `OIDCAuthPlugin` makes two `requests.get()` calls with no explicit `timeout`. A hanging SSO server blocks a Gunicorn worker indefinitely. The registry plugin correctly sets `timeout=self.request_timeout`. This gap has been documented but not fixed.
+
+**Authorization predicates use `eval()`.** SAML, X.509, and registry auth plugins evaluate Python expressions from backends YAML via `eval()`. Safe only because predicates come from trusted configuration (app-interface MRs), never user input. An `eval()` error in a predicate propagates unhandled.
+
+**No graceful JWKS key rotation detection.** JWKS certificates are cached for 24 hours. If SSO rotates keys, JWTs signed with the new key fail validation until the cache expires.
+
+**Backend matching is linear.** Route lookup iterates all backends for the longest prefix match. Nginx's `X-Matched-Backend` header provides an exact name lookup on the common path.

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -1,0 +1,145 @@
+# API Contracts Guidelines
+
+## Architecture Overview
+
+Turnpike is an nginx `auth_request` subrequest handler. Nginx intercepts every inbound request, sends an internal subrequest to `/auth/`, and the Flask policy service returns a status code (200, 401, 403, or 500) with optional response headers. Nginx then either proxies the original request to the upstream origin or rejects it.
+
+## Endpoints
+
+### Internal (nginx-only) endpoints
+
+| Path | Method | Purpose | Response |
+|---|---|---|---|
+| `/auth/` | GET | Policy evaluation subrequest. Never called directly by clients. | Empty body; status code + headers |
+| `/_healthcheck/` | GET | Liveness probe | JSON health status |
+| `/_nginx_config/` | GET | Returns header-forwarding and blueprint metadata for the nginx config builder | JSON with `to_upstream`, `to_policy_service`, `blueprints` |
+| `/metrics` | GET | Prometheus metrics (served via WSGI middleware, not Flask) | Prometheus text format |
+
+### Client-facing endpoints
+
+| Path | Method | Purpose | Response |
+|---|---|---|---|
+| `/api/turnpike/identity/` | GET | Decode and return the current `X-Rh-Identity` header | JSON identity object or `{"error": "..."}` |
+| `/api/turnpike/session/` | GET | Return the current session cookie value | `{"session": "..."}` or `{"error": "..."}` |
+
+### SAML endpoints (under `/saml/` blueprint)
+
+Two parallel sets exist under `/saml/internal/` and `/saml/private/`, each bound to its own SAML IdP configuration.
+
+| Path suffix | Method | Purpose |
+|---|---|---|
+| `/login/` | GET | Redirect to IdP; accepts `?next=` for post-login redirect |
+| `/acs/` | POST | Assertion Consumer Service; processes IdP response, sets session, redirects to `RelayState` or `/` |
+| `/metadata.xml` | GET | SP metadata (XML, `Content-Type: text/xml`) |
+| `/sls/` | GET | Single Logout Service; clears session, redirects |
+| `/mock/` | POST | Test-only; stores posted JSON as SAML assertion in session. Returns `204 No Content`. Requires `Content-Type: application/json`. Returns `404` when `TESTING` is not enabled, `415` for wrong content type. |
+
+## Status Code Conventions
+
+The `/auth/` endpoint returns only status codes with an empty body. Nginx interprets these to decide whether to proxy or reject.
+
+| Code | Meaning | Set by |
+|---|---|---|
+| `200` | Request allowed (default when no plugin sets a code) | `DEFAULT_RESPONSE_CODE` config, end of plugin chain |
+| `401` | Authentication failed (no plugin authenticated the request) | `AuthPlugin` fallback, `OIDCAuthPlugin` (bad/missing/expired token), `RegistryAuthPlugin` (credential or service failures) |
+| `403` | Forbidden (authenticated but not authorized, or VPN/source-IP restriction failed) | `SAMLAuthPlugin`, `X509AuthPlugin`, `RegistryAuthPlugin` (predicate fails), `VPNPlugin`, `SourceIPPlugin` |
+| `500` | Internal error (OIDC keyset fetch failure) | `OIDCAuthPlugin` |
+
+Rules:
+- A plugin sets `context.status_code` to short-circuit the chain; no further plugins run.
+- If no plugin sets a status code and no plugin authenticates, `AuthPlugin` sets `401`.
+- If no auth is required for the backend (no `auth` key), the request passes through to `DEFAULT_RESPONSE_CODE` (200).
+
+## Request Headers (nginx to Flask)
+
+These headers are set by nginx on the subrequest to `/auth/` and consumed by the Flask policy service.
+
+| Header | Source | Purpose |
+|---|---|---|
+| `X-Original-URI` | `$request_uri` | The original client request URI; used for route matching when `X-Matched-Backend` is absent |
+| `X-Matched-Backend` | `$matched_backend` (set per-location) | Backend name matched by nginx; preferred over URI-based matching |
+| `X-Rh-Edge-Host` | Upstream edge proxy | Identifies network origin (`internal` vs `private`); validated by `VPNPlugin` against regex |
+| `X-Forwarded-For` | Standard proxy header | Used by `SourceIPPlugin` to extract client IP (hop count configured via `HOPS_TO_EDGE`) |
+| `X-Forwarded-Host` | `$host` | Forwarded to Flask; used by `ProxyFix` middleware |
+| `X-Forwarded-Port` | Hardcoded `443` | Always set to 443 |
+| `X-Forwarded-Proto` | Hardcoded `https` | Always set to https |
+| `Authorization` | Client | Consumed by `OIDCAuthPlugin` (`Bearer` scheme) and `RegistryAuthPlugin` (`Basic` scheme) |
+| `x-rh-certauth-cn` | mTLS gateway (configurable via `HEADER_CERTAUTH_SUBJECT`) | X.509 client certificate subject DN |
+| `x-rh-certauth-issuer` | mTLS gateway (configurable via `HEADER_CERTAUTH_ISSUER`) | X.509 client certificate issuer DN |
+| PSK header | mTLS gateway (name configurable via `HEADER_CERTAUTH_PSK`) | Pre-shared key for CDN/gateway certificate validation |
+
+Plugins declare which headers they need via `headers_needed` (forwarded to the policy service) and `headers_to_forward` (forwarded from the policy response to the upstream origin). The nginx config builder dynamically generates `proxy_set_header` directives from these sets.
+
+## Response Headers (Flask to upstream)
+
+| Header | Set by | Content |
+|---|---|---|
+| `X-RH-Identity` | `RHIdentityPlugin` | Base64-encoded JSON identity object; forwarded by nginx to the upstream origin |
+
+The `X-RH-Identity` payload structure depends on the authentication method:
+
+- **SAML** (`type: "Associate"`, `auth_type: "saml-auth"`): Contains user attributes from the SAML assertion (e.g., `Role`, `email`, `givenName`, `rhatUUID`, `surname`).
+- **X.509** (`type: "X509"`, `auth_type: "X509"`): Contains `subject_dn` and `issuer_dn`.
+- **OIDC** (`type: "Service_Account"`, `auth_type: "oidc-service-account"`): Contains `client_id`, `preferred_username`, and `scopes`.
+- **Registry** (`type: "Registry"`, `auth_type: "registry-auth"`): Contains `org_id` and `username`.
+
+## Backend Configuration Contract
+
+Backends are defined in a YAML list (loaded from `BACKENDS_CONFIG_MAP`). Each entry must conform to:
+
+```yaml
+- name: my-service              # Required. Unique string identifier.
+  route: /api/my-service/       # Required. URL prefix for matching. Must start with /.
+  origin: http://svc.cluster.local:8080/  # Required. Proxy target. Must be in an allowed domain.
+  private: false                # Optional. VPN-restricted if true. Default: false.
+  timeout: 60                   # Optional. Nginx timeout in seconds. Default: 60.
+  buffering: "on"               # Optional. "on" or "off". Default: "on".
+  source_ip:                    # Optional. List of allowed CIDR blocks.
+    - 10.0.0.0/8
+  auth:                         # Optional. If absent, no auth required (route must be under /public/).
+    saml: "True"                # Python expression evaluated with `user` dict.
+    x509: "True"                # Python expression evaluated with `x509` dict.
+    oidc:                       # OIDC service account definitions.
+      serviceAccounts:
+        - clientId: <uuid>      # Required within each SA entry.
+          scopes:               # Optional. All listed scopes must be present in token.
+            - scope_a
+    registry: "True"            # Python expression evaluated with `registry` dict.
+```
+
+Validation rules enforced at startup and by the nginx config builder:
+- Routes must start with `/` and be a valid URL path.
+- Origins must be in a domain from `TURNPIKE_ALLOWED_ORIGIN_DOMAINS` (default: `.svc.cluster.local`).
+- Routes under `saml`, `auth`, `_nginx` are reserved and rejected.
+- First path segment must be in `TURNPIKE_ALLOWED_ROUTES` (default: `public`, `api`, `app`) or start with `_`.
+- Routes without `auth` or `source_ip` must have their first segment in `TURNPIKE_NO_AUTH_ROUTES` (default: `public`).
+- OIDC backends: every `serviceAccounts` entry must have a non-empty `clientId`; `scopes` if present must be a non-empty list with no empty strings.
+
+## Route Matching
+
+1. If nginx sends `X-Matched-Backend`, Turnpike looks up the backend by `name` (exact match).
+2. Otherwise, Turnpike matches by longest `route` prefix against `X-Original-URI`.
+3. If no backend matches, the response is `403` (indicates a configuration mismatch).
+
+## Plugin Chain
+
+Plugins execute in `PLUGIN_CHAIN` order. The default chain is:
+
+1. **VPNPlugin** -- Rejects requests to `private: true` backends unless `X-Rh-Edge-Host` indicates the private network.
+2. **AuthPlugin** -- Runs the `AUTH_PLUGIN_CHAIN` (OIDC, Registry, SAML, X509) in order. First plugin to authenticate wins. If none authenticates, returns 401.
+3. **SourceIPPlugin** -- Enforces `source_ip` CIDR allowlists using `X-Forwarded-For`.
+4. **RHIdentityPlugin** -- Constructs and attaches the `X-RH-Identity` header from auth data.
+
+Auth plugin processing: each auth plugin checks whether its auth type key exists in the backend's `auth` dict. If absent, it skips. If present, it attempts authentication. On success it sets `context.auth`; on authorization failure (predicate evaluates to `False`) it sets `context.status_code = 403`.
+
+## SAML Login Redirect Flow
+
+When a backend with `saml` auth returns `401`, nginx's `error_page 401 = @error401` redirects the client to the appropriate SAML login page:
+- Internal network: `https://{INTERNAL_HOSTNAME}/saml/internal/login/?next=$request_uri`
+- Private/VPN network (detected via `X-Rh-Edge-Host` containing "private"): `https://{PRIVATE_HOSTNAME}/saml/private/login/?next=$request_uri`
+
+Only backends with `saml` in their `auth` block get the `error_page 401` directive.
+
+## Metrics
+
+A single Prometheus counter `requests` is tracked with labels `service` (backend name) and `policy_status_code`.

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -1,0 +1,121 @@
+# Error Handling Guidelines
+
+## Architecture Context
+
+Turnpike is an nginx `auth_request` subrequest handler. The `/auth/` endpoint returns empty-body responses with status codes that nginx interprets as allow/deny decisions. Plugins communicate outcomes by setting `context.status_code` on a `PolicyContext` object -- they never raise exceptions to signal authorization failure.
+
+## Status Code Semantics
+
+| Code | Meaning | Where Used |
+|------|---------|------------|
+| `None` | No decision yet; continue plugin chain | Default on `PolicyContext` |
+| `200` | Request allowed (`DEFAULT_RESPONSE_CODE`) | End of plugin chain with no explicit decision |
+| `401` | Authentication failed (no valid credentials) | `AuthPlugin` (no plugin authenticated), `OIDCAuthPlugin`, `RegistryAuthPlugin` |
+| `403` | Forbidden (authenticated but unauthorized, or structurally invalid request) | `SAMLAuthPlugin`, `X509AuthPlugin`, `RegistryAuthPlugin`, `VPNPlugin`, `SourceIPPlugin`, unmatched route in `policy_view` |
+| `500` | Internal infrastructure failure | `OIDCAuthPlugin` (keyset fetch failure), SAML ACS/SLS/Metadata views |
+| `404` | Test-only guard | `MockSAMLAssertionView` when `TESTING` is falsy |
+| `415` | Wrong content type | `MockSAMLAssertionView` for non-JSON |
+
+Rules:
+
+1. Use `HTTPStatus.UNAUTHORIZED` (401) when credentials are absent, malformed, expired, or the principal is not recognized at all.
+2. Use `HTTPStatus.FORBIDDEN` (403) when the principal is authenticated but fails the authorization predicate (`eval(predicate, ...)`), or when the request is structurally rejected (wrong network, missing required header, IP not in allowlist).
+3. Use `HTTPStatus.INTERNAL_SERVER_ERROR` (500) only for failures in Turnpike's own infrastructure (cannot reach SSO, cannot build JWKS keyset, SAML metadata invalid). Never use 500 for client-caused errors. Note: the Registry plugin is an exception -- it returns 401 (not 500) on connection failure to the registry service, treating the request as unauthenticated.
+4. `policy_view` returns empty-body responses (`make_response("", status_code)`). Do not include error detail in the response body from the `/auth/` endpoint -- nginx does not forward it.
+
+## Plugin Error-Flow Convention
+
+Plugins must never raise exceptions to signal auth outcomes. The pattern is:
+
+```python
+# Set status_code and return -- do not raise
+context.status_code = HTTPStatus.UNAUTHORIZED
+return context
+```
+
+When `context.status_code` is set to any non-None value, the plugin chain short-circuits immediately in `policy_view`. When `context.auth` is set (successful authentication), the inner auth plugin chain inside `AuthPlugin` stops processing further auth plugins -- but the outer `PLUGIN_CHAIN` loop in `policy_view` continues running (it only short-circuits on `context.status_code`).
+
+Auth plugins that do not handle a given auth type must return `context` unmodified (no status_code, no auth), allowing the next auth plugin to try.
+
+## Startup Validation (Fail-Fast)
+
+The application validates configuration at import/boot time and crashes intentionally on misconfiguration. There are two categories:
+
+**`ValueError` -- missing required environment variables** (`config.py`, `registry.py`) **or invalid plugin class** (`turnpike/__init__.py`, `turnpike/plugins/auth.py`):
+```python
+if not SECRET_KEY:
+    raise ValueError("No SECRET_KEY set.")
+```
+Used for: `SECRET_KEY`, `SSO_OIDC_HOST`, `SSO_OIDC_PORT`, `SSO_OIDC_PROTOCOL_SCHEME`, `SSO_OIDC_REALM`, `REGISTRY_SERVICE_URL`, `REGISTRY_SERVICE_CLIENT_CERT_PATH`, `REGISTRY_SERVICE_CLIENT_KEY_PATH`. Also raised when a plugin class is not a valid `TurnpikePlugin` subclass (`turnpike/__init__.py`) or not a valid `TurnpikeAuthPlugin` subclass (`turnpike/plugins/auth.py`).
+
+**`NotImplementedError` -- structurally invalid backend definitions** (`__init__.py:validate_oidc_definitions`):
+Raised when OIDC backend configuration is incomplete (empty `oidc` object, empty `serviceAccounts` list, missing `clientId`, empty `scopes`). Also raised when no backends are configured at all.
+
+**`InvalidBackendDefinitionError` -- nginx config builder** (`build_config.py`):
+Custom exception for invalid routes (bad URL path, untrusted origin domain, protected route, missing both `auth` and `source_ip` blocks on a non-public route). Caught at the `main()` level and exits with code 1.
+
+Rule: All new required configuration must follow the same pattern -- validate at startup, raise `ValueError` with a message naming the missing variable. Do not silently default required values.
+
+## Custom Exception Classes
+
+| Exception | Location | Purpose |
+|-----------|----------|---------|
+| `UnableCreateKeysetError` | `turnpike/plugins/oidc/unable_create_keyset_error.py` | Wraps all failures in JWKS keyset construction (network errors, unexpected status codes, parsing failures). Caught in `OIDCAuthPlugin.process()` and converted to 500. |
+| `InvalidBackendDefinitionError` | `nginx/configuration_builder/build_config.py` | Backend route validation failures during nginx config generation. |
+
+Rule: Domain-specific exceptions should be defined in their own module file (as `UnableCreateKeysetError` demonstrates). Internal helper methods raise the domain exception; the `process()` method catches it and sets the appropriate status code.
+
+## Logging Conventions
+
+The codebase uses Flask's `app.logger` (or `current_app.logger`) exclusively inside the application. The nginx config builder uses Python's standard `logging` module since it runs outside Flask.
+
+**Log levels in practice:**
+
+| Level | Usage |
+|-------|-------|
+| `debug` | Normal flow: plugin entry, skipping inapplicable plugins, successful operations |
+| `info` | Plugin registration, VPN denials (for audit), SAML attribute debug (behind `AUTH_DEBUG` flag) |
+| `warning` | Unexpected but client-attributable failures: malformed credentials, invalid response from upstream, unconfigured route matched, backend config missing optional `auth` |
+| `error` | Infrastructure failures: cannot reach SSO/OIDC, registry request exception, invalid edge-host header value on VPN-restricted backend |
+| `exception` | Used exactly once (`SourceIPPlugin`) for malformed `X-Forwarded-For` -- includes traceback |
+
+Rules:
+
+1. Prefer `logger.warning` for client-caused failures and `logger.error` for infrastructure failures. The registry plugin uses `logger.error` for connection failures to the registry service (which result in 401, not 500) -- this is an existing exception to the general pattern.
+2. Use `logger.exception` (with traceback) only for truly unexpected errors, not for routine auth failures.
+3. Sensitive data logging is gated behind the `AUTH_DEBUG` config flag. SAML attributes and x509 header values are only logged at `info` level when `AUTH_DEBUG` is truthy.
+4. Log messages for VPN and header validation include a structured prefix: `[backend: "name"][header: "value"]`.
+5. Never log passwords or bearer token values. The OIDC plugin logs token decode errors but not the token itself.
+
+## SAML View Error Handling
+
+SAML views (`ACSView`, `SLSView`, `MetadataView`) follow a distinct pattern from plugins because they are user-facing HTTP endpoints, not `auth_request` subrequests:
+
+- **`ACSView` and `SLSView`**: check `saml_authentication.get_errors()` after processing. On error: return 500 with `text/plain` content type. The error reason is only included in the body when SAML debug mode is active (`is_debug_active()`); otherwise the body is empty.
+- **`MetadataView`**: calls `settings.validate_metadata(metadata)`. On error: return 500 with the error list always included in the body (no `is_debug_active()` check; no explicit `Content-Type` override on the error response).
+- On success: redirect (ACS, SLS) or return XML metadata (`Content-Type: text/xml`).
+
+## External Service Failure Handling
+
+When calling external services (SSO/OIDC, Registry), the pattern is:
+
+1. Catch broad `Exception` from the `requests` call.
+2. Log at `error` level with the exception message.
+3. Set `context.status_code` to the appropriate HTTP status.
+4. Return context immediately -- do not re-raise.
+
+The OIDC plugin wraps all external call failures into `UnableCreateKeysetError` in the helper, then catches that single exception type in `process()` and sets 500. The Registry plugin handles each failure inline without a wrapper exception and sets 401 (not 500) on connection failure -- treating an unreachable registry as an authentication failure rather than an infrastructure error.
+
+The nginx config builder retries the Flask service URL in a loop (`while not response_obj`) when it gets `URLError`, since Flask may still be starting. This is the only retry pattern in the codebase.
+
+## Response Body Conventions
+
+- `/auth/` endpoint: always empty body (`make_response("", status_code)`).
+- `/api/turnpike/identity/`: returns JSON with either decoded identity or `{"error": "..."}`.
+- `/api/turnpike/session/`: returns JSON with either session ID or `{"error": "..."}`.
+- SAML views: return redirects on success, plain text error on failure (except `MetadataView`, which has no explicit `Content-Type` on its error response).
+- `/_nginx_config/`: returns JSON, no error handling (assumes internal-only access).
+
+## Authorization Predicate Errors
+
+Backend auth predicates are evaluated via `eval(predicate, dict(...))`. If the predicate raises an exception, it propagates unhandled -- there is no try/except around `eval()` calls in `SAMLAuthPlugin`, `X509AuthPlugin`, or `RegistryAuthPlugin`. Predicate expressions must be valid Python that evaluates to a truthy/falsy value given the provided context dict.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -1,0 +1,141 @@
+# Integration Guidelines
+
+Rules and conventions for outbound HTTP calls, external service integration, and nginx interop in Turnpike.
+
+## Architecture Overview
+
+Turnpike operates as two containers: an **nginx reverse proxy** and a **Flask policy service**. Nginx delegates every auth decision to Flask via `auth_request /auth/`. Flask never proxies traffic itself; it only returns status codes (200, 401, 403) and response headers that nginx forwards to upstream backends.
+
+## Outbound HTTP Call Conventions
+
+### 1. Use `requests` for all outbound calls
+
+All outbound HTTP calls use the `requests` library directly. There is no shared HTTP client, session pool, or wrapper. Each plugin instantiates its own calls.
+
+### 2. No retry logic -- fail immediately
+
+No plugin implements retries. When an outbound call fails (connection error, unexpected status code), the plugin logs the error and returns a failure status code on the `PolicyContext`. Do not add retry loops to auth-path calls; latency on the `auth_request` subrequest directly blocks the user's request in nginx.
+
+### 3. Timeout conventions
+
+| Integration point | Timeout | Source |
+|---|---|---|
+| Registry service POST | `REGISTRY_SERVICE_TIMEOUT` env var, default **10s** | `registry.py` constructor |
+| OIDC well-known / JWKS GET | **None set** (uses `requests` default, which is unlimited) | `oidc.py` |
+| Nginx upstream proxy | `timeout` per backend YAML entry, default **60s** | `build_config.py` `NGINX_DEFAULT_TIMEOUT` |
+
+When adding a new outbound call, always pass an explicit `timeout=` to `requests`. The OIDC plugin's omission of a timeout is a known gap, not a pattern to follow.
+
+### 4. Error handling: set `context.status_code`, never raise
+
+Auth plugins must catch all exceptions from outbound calls internally. On infrastructure failure (cannot reach SSO, cannot reach registry), set `context.status_code` to `HTTPStatus.INTERNAL_SERVER_ERROR` or `HTTPStatus.UNAUTHORIZED` and return the context. Never let an exception propagate out of `process()`.
+
+```python
+# Correct pattern (from registry.py):
+try:
+    res = requests.post(url=self.registry_url, ..., timeout=self.request_timeout)
+except Exception as e:
+    self.app.logger.error(f"Registry authentication request failed: {e}")
+    context.status_code = HTTPStatus.UNAUTHORIZED
+    return context
+```
+
+### 5. Log at the right level
+
+- `logger.error()` -- connection-level outbound call failures (cannot reach the external service at all)
+- `logger.warning()` -- auth rejections where the caller provided credentials that were invalid, and unexpected but non-exception responses from external services (e.g., the registry service returning a non-200 status code)
+- `logger.debug()` -- normal flow decisions (plugin skipped, cache hit, header inspection)
+
+## Caching
+
+### 6. Use `turnpike.cache` (Flask-Caching backed by Redis)
+
+All cached values go through the `turnpike.cache` module, which is a `flask_caching.Cache` instance initialized with Redis in production and `SimpleCache` in tests.
+
+### 7. Cache key and TTL conventions
+
+| Cached data | Key pattern | TTL | Rationale |
+|---|---|---|---|
+| OIDC JWKS certificates | `oidc_jwks_response` (singleton) | **86400s (24h)** | Certificates rotate infrequently |
+| Registry auth results | `registry_auth:{user}:{sha256(password)}` | `REGISTRY_AUTH_CACHE_TTL`, default **300s** | Avoid hammering registry on repeated requests |
+
+Cache keys for per-user data must include a credential hash so that changed credentials cause a cache miss. See `registry.py` for the pattern using `hashlib.sha256`.
+
+## mTLS Client Certificate Usage
+
+### 8. Registry plugin: outbound mTLS via `cert=` parameter
+
+The registry plugin authenticates to the external registry service using a client certificate. Paths are configured via `REGISTRY_SERVICE_CLIENT_CERT_PATH` and `REGISTRY_SERVICE_CLIENT_KEY_PATH` environment variables. The `verify` parameter is controlled by `REGISTRY_SERVICE_SSL_VERIFY`.
+
+```python
+requests.post(
+    url=self.registry_url,
+    json={"credentials": {"username": user, "password": password}},
+    cert=(self.client_cert_path, self.client_key_path),
+    verify=self.ssl_verify,
+    timeout=self.request_timeout,
+)
+```
+
+### 9. Inbound mTLS: handled by nginx, not Flask
+
+Nginx terminates inbound client TLS and populates `x-rh-certauth-cn` / `x-rh-certauth-issuer` headers. The `X509AuthPlugin` reads these headers; it never touches certificates directly. A pre-shared key header (`HEADER_CERTAUTH_PSK` / `CDN_PRESHARED_KEY`) must also match for X.509 auth to succeed.
+
+## OIDC / JWKS Integration
+
+### 10. Two-step JWKS fetch: well-known then jwks_uri
+
+The OIDC plugin first GETs `{host}/.well-known/openid-configuration`, extracts `jwks_uri` from the JSON response, then GETs that URI. Both calls use `requests.get()` with no timeout (see rule 3). The combined result is cached as a single key.
+
+### 11. Issuer URL excludes port; host URL includes port
+
+The `host` field (used for HTTP calls) includes the port: `{scheme}://{host}:{port}/auth/realms/{realm}`. The `issuer` field (used for JWT `iss` claim validation) excludes the port. Mixing these up will cause either connection failures or token validation failures.
+
+## SAML Integration
+
+### 12. SAML uses `python3-saml` (OneLogin), not outbound HTTP
+
+SAML authentication is handled entirely through the `python3-saml` library and browser redirects. There are no outbound HTTP calls from the Flask process for SAML. The SSO interaction happens via the user's browser (302 redirects to SSO, POST back to `/saml/.../acs/`).
+
+### 13. Dual SAML settings: internal vs. private
+
+Two independent SAML configurations exist (`INTERNAL_SAML_PATH`, `PRIVATE_SAML_PATH`), selected by `SAMLSettingsType`. The nginx `@error401` handler determines which SAML login endpoint to redirect to based on the `X-Rh-Edge-Host` header.
+
+## Nginx Integration
+
+### 14. auth_request subrequest contract
+
+Nginx sends `auth_request /auth/` for every proxied location. Flask responds with:
+- **200** -- request is authorized; nginx forwards headers set in `context.headers` to the upstream
+- **401** -- triggers `@error401` redirect to SAML login (only for SAML-enabled backends)
+- **403** -- request is forbidden
+
+Flask receives the original request URI via the `X-Original-Uri` header and the matched backend name via `X-Matched-Backend`.
+
+### 15. Configuration builder startup sequence
+
+The nginx container runs `build_config.py` at startup, which polls `{FLASK_SERVICE_URL}/_nginx_config/` in a retry loop (3-second sleep) until Flask is available. This endpoint returns the set of headers that plugins need forwarded. Nginx locations are generated from the backends YAML using Jinja2 templates.
+
+### 16. Backend YAML `timeout` and `buffering` fields
+
+Each backend entry supports optional `timeout` (integer seconds, default 60) and `buffering` (`"on"` or `"off"`, default `"on"`) fields. These control nginx `proxy_read_timeout`, `proxy_send_timeout`, `send_timeout`, `client_body_timeout`, and `proxy_buffering`/`proxy_request_buffering` for that location.
+
+## Plugin Chain Conventions
+
+### 17. Auth plugin chain: first match wins
+
+The `AUTH_PLUGIN_CHAIN` is evaluated in order. The first plugin that sets `context.auth` (success) or `context.status_code` (failure) stops the chain. Plugins that do not recognize the request (wrong header, missing backend auth key) must return the context unmodified with `status_code=None` and `auth=None`.
+
+### 18. Plugin initialization: validate config eagerly
+
+Required configuration (URLs, cert paths, env vars) must be validated in `__init__`. The registry plugin raises `ValueError` for missing config. The OIDC backend definitions are validated at app startup in `validate_oidc_definitions()`. Fail at boot, not at request time.
+
+## Testing Outbound Calls
+
+### 19. Mock at the `requests` method level
+
+Tests mock `requests.get` or `requests.post` via `unittest.mock.patch` at the module where they are imported. Use `side_effect` for conditional responses based on URL. Use `SimpleCache` (`CACHE_TYPE: "SimpleCache"`) in test configs to avoid requiring Redis.
+
+### 20. Verify caching with call counts
+
+Assert that repeated calls to a plugin with the same input do not increase the mock's `call_count`. See `test_oidc_requests_get_cached` and `test_registry_requests_get_cached` for the pattern.

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -1,0 +1,123 @@
+# Performance Guidelines
+
+Turnpike is an nginx `auth_request` subrequest handler. Every authenticated request to a backend triggers a subrequest to the Flask policy service before nginx proxies to the upstream. Latency in the policy service directly adds to every request's total latency.
+
+## Architecture Constraints
+
+- **Gunicorn runs 4 sync workers** (`run-server.sh`: `gunicorn -w 4`). Each worker handles one request at a time. Any blocking I/O in a plugin stalls that worker entirely.
+- **nginx uses 1 worker process** with 1024 connections (`nginx.conf`). The auth subrequest is `internal` and uses `proxy_pass_request_body off` to avoid forwarding bodies to the policy service.
+- **The policy chain is sequential.** Plugins in `PLUGIN_CHAIN` run in order (VPN, Auth, SourceIP, RHIdentity). The auth sub-chain (`AUTH_PLUGIN_CHAIN`) also runs sequentially (OIDC, Registry, SAML, X509). A slow plugin blocks all downstream plugins for that request.
+- **Default resource limits** are 200m-500m CPU and 256Mi-512Mi memory for the web container (see `templates/web.yml`).
+
+## Redis: Sessions and Cache
+
+Redis backs two independent subsystems, both connecting to the same `REDIS_HOST`:
+
+1. **Flask-Session** (`SESSION_TYPE = "redis"`): Stores SAML session data. Session lifetime is 4 hours (`PERMANENT_SESSION_LIFETIME = 60 * 60 * 4`).
+2. **Flask-Caching** (`CACHE_TYPE = "RedisCache"`): Used by OIDC and Registry auth plugins for response caching.
+
+Rules:
+- Never use `flask.session` for caching auth decisions. Use the `cache` instance from `turnpike.cache` (a `flask_caching.Cache` object) with an explicit `timeout`.
+- Always provide a `timeout` argument to `cache.set()`. Omitting it risks unbounded key growth.
+- The session Redis connection is created at import time in `config.py` with no connection pooling configuration (`SESSION_REDIS = redis.Redis(...)`). Do not add per-request Redis connection creation.
+
+## Caching Conventions
+
+Two caching patterns exist in the codebase. Follow them exactly:
+
+### OIDC JWKS Certificates (24-hour TTL)
+
+The OIDC plugin caches the entire JWKS response under a single global key `oidc_jwks_response` with an 86400-second (24h) TTL. This avoids hitting the SSO server on every JWT-authenticated request.
+
+```python
+# In _get_jwks_keyset():
+jwks_certificates = cache.get("oidc_jwks_response")
+if not jwks_certificates:
+    # ... fetch from SSO ...
+    cache.set(key="oidc_jwks_response", value=jwks_certificates, timeout=86400)
+```
+
+- The cache key is static (shared across all workers/pods).
+- When the SSO rotates keys, the 24h window is the maximum staleness.
+
+### Registry Auth (5-minute TTL, per-credential)
+
+The Registry plugin caches successful auth results per user+password-hash:
+
+```python
+cache_key = f"registry_auth:{user}:{password_hash}"
+cache.set(key=cache_key, value=True, timeout=self.cache_ttl)
+```
+
+- `REGISTRY_AUTH_CACHE_TTL` defaults to 300 seconds (env-configurable).
+- Password is SHA-256 hashed before inclusion in the cache key -- never store plaintext credentials in cache keys.
+- Only successful auth results are cached. Failed attempts always hit the external registry service.
+
+### Adding New Cached Data
+
+When introducing a new cache entry:
+1. Use a namespaced key prefix (e.g., `plugin_name:identifier`).
+2. Always set an explicit `timeout`.
+3. Test that the cache is hit on the second call (see `test_oidc_requests_get_cached` and `test_registry_requests_get_cached` for the pattern).
+4. Use `SimpleCache` in test configs (`"CACHE_TYPE": "SimpleCache"`) to avoid requiring a Redis instance.
+
+## External HTTP Calls
+
+Only two plugins make outbound HTTP requests during policy evaluation:
+
+| Plugin | Target | Timeout | Caching |
+|--------|--------|---------|---------|
+| `OIDCAuthPlugin` | SSO OIDC config + JWKS endpoint | **None set** (uses `requests` default) | 24h for JWKS |
+| `RegistryAuthPlugin` | Registry service (mTLS) | `REGISTRY_SERVICE_TIMEOUT` (default 10s) | 5min per credential |
+
+Rules:
+- **Always set `timeout=` on `requests.get()` and `requests.post()` calls.** The OIDC plugin currently omits explicit timeouts on its HTTP calls. New plugins must not repeat this -- always pass a `timeout` parameter.
+- The Registry plugin correctly uses `timeout=self.request_timeout`. Follow this pattern for any new external calls.
+- Wrap all outbound calls in try/except. The OIDC plugin wraps all network and parsing failures into `UnableCreateKeysetError` inside `_get_jwks_keyset()`, then catches that domain exception in `process()` and returns 500. The Registry plugin catches `Exception` directly inline and returns 401. Either approach is acceptable; the critical requirement is that no exception escapes `process()`.
+
+## Nginx Timeout and Buffering
+
+Per-backend timeouts and buffering are configured in the backends YAML and applied via the nginx location template (`nginx_location_template.conf.j2`):
+
+```yaml
+- name: my-backend
+  route: /api/my-service/
+  origin: http://my-service.svc.cluster.local:8080/
+  timeout: 90        # seconds; default is 60 (NGINX_DEFAULT_TIMEOUT_SECONDS)
+  buffering: "off"   # "on" (default) or "off"
+```
+
+The timeout value applies to `send_timeout`, `client_body_timeout`, `proxy_read_timeout`, and `proxy_send_timeout` simultaneously.
+
+Rules:
+- Only increase `timeout` above 60s when the upstream genuinely needs it (e.g., long-running report endpoints). Document why.
+- Set `buffering: "off"` only for streaming or SSE backends. Buffering is more efficient for typical request/response patterns.
+- The auth subrequest location (`/auth/`) has custom buffer sizes: `proxy_buffer_size 16k`, `proxy_busy_buffers_size 24k`, `proxy_buffers 64 4k`. These accommodate large auth response headers (e.g., base64-encoded `X-RH-Identity`). Do not reduce these without testing with full SAML session data.
+
+## DNS Resolution
+
+Nginx resolves upstream hostnames using the system resolver with a 60-second cache (`resolver {{ resolver }} valid=60s`). This means DNS changes take up to 60 seconds to propagate. Do not lower `valid=` below 60s in production.
+
+## Plugin Chain Performance
+
+- Plugins that can short-circuit should do so early. The VPN plugin checks the `private` flag before any header validation. The Auth plugin skips entirely if no `auth` block is defined on the backend. Follow this pattern.
+- Avoid adding logging at INFO or higher in the hot path. Use `DEBUG` level for per-request diagnostics. The root logger is set to `DEBUG` level, so ensure log volume is acceptable.
+- The `match_by_backend_name` function does a linear scan of `BACKENDS`. For the current deployment scale (tens of backends), this is fine. If the backend count grows to hundreds, consider indexing by name.
+
+## Metrics
+
+- The `requests` counter (Prometheus) tracks `(service, policy_status_code)` labels. Keep cardinality low -- do not add high-cardinality labels (e.g., user IDs, request paths).
+- Metrics are exposed via `/metrics` using `DispatcherMiddleware`. This endpoint is served by the same gunicorn workers. Do not add expensive computation to metric collection.
+- The Grafana dashboard (`dashboards/grafana-dashboard-turnpike.configmap.yaml`) monitors CPU, memory, restarts, and request status code distribution for `web`, `nginx`, and `prometheus-nginx` containers.
+
+## Health Checks
+
+- Readiness and liveness probes hit `/_healthcheck/` on port 5000 with a 3-second timeout and 10-second period.
+- The nginx health endpoint (`/_nginx/`) returns a static 200 with `access_log off` -- it adds no load.
+- Do not add expensive operations (DB queries, external calls) to the healthcheck handler.
+
+## Testing Considerations
+
+- Test configs should use `"CACHE_TYPE": "SimpleCache"` to avoid Redis dependencies.
+- Cache behavior tests must verify both cache-miss (first call hits external service) and cache-hit (second call does not) scenarios. See `test_oidc_requests_get_cached` and `test_registry_requests_get_cached`.
+- When testing plugins that make external HTTP calls, mock at the `requests.get`/`requests.post` level, not at the cache level, to ensure caching logic is exercised.

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,77 @@
+# Security Guidelines
+
+Rules and conventions for contributing to Turnpike, the nginx `auth_request` policy gateway.
+
+## Architecture Invariants
+
+1. Turnpike runs as an nginx `auth_request` subrequest handler. The `/auth/` location is marked `internal;` in nginx -- it must never be exposed externally. Do not add routes that would shadow or expose it.
+2. The nginx config builder (`nginx/configuration_builder/build_config.py`) enforces that backend routes cannot start with the reserved segments `saml`, `auth`, or `_nginx` (`PROTECTED_ROUTES`). Never weaken this list.
+3. Backend origins must resolve to a domain in `TURNPIKE_ALLOWED_ORIGIN_DOMAINS` (default: `.svc.cluster.local`). This prevents backends from proxying to arbitrary external hosts.
+4. Every non-public backend must declare either an `auth` block or a `source_ip` block. Backends under `/public/` are the only ones allowed without access restrictions. The config builder rejects anything else at startup.
+
+## Plugin Chain & PolicyContext
+
+5. The policy chain order matters: VPN -> Auth -> SourceIP -> RHIdentity. VPN restriction is checked first; identity header enrichment happens last. Do not reorder without understanding the security implications.
+6. A plugin that sets `context.status_code` short-circuits the chain -- no further plugins run and the response is returned immediately. Always set `status_code` (not just return early) when denying a request.
+7. When the entire auth plugin chain completes without authenticating, `AuthPlugin` returns 401. Individual auth plugins should return the context unmodified (not set 401) when they simply do not apply -- the fallback handles the denial.
+8. `PolicyContext.headers` is a mutable dict shared across all plugins. Only add headers you intend the upstream to see. The `X-RH-Identity` header is constructed by `RHIdentityPlugin` and forwarded via nginx `auth_request_set` directives.
+
+## Authorization Predicates (eval)
+
+9. The `saml`, `x509`, and `registry` auth plugins use `eval()` to evaluate backend authorization predicates from the YAML config. The predicate string (e.g., `'x509["subject_dn"].startswith("/CN=allowed")'`) is executed with a restricted namespace containing only the auth data dict. **Never** allow user-controlled input to flow into these predicates. They are trusted configuration, not request data.
+10. OIDC backends do **not** use `eval()`. Authorization is determined by matching `clientId` and `scopes` from the JWT against the backend's `serviceAccounts` list.
+
+## OIDC / JWT Authentication
+
+11. JWT tokens are verified against JWKS keys fetched from the SSO OIDC provider. The JWKS response is cached for 24 hours (`timeout=86400` in `_get_jwks_keyset`). If you change caching behavior, ensure stale keys are still rotated.
+12. The OIDC plugin validates these JWT claims as **essential**: `exp` (not expired) and `iss` (must match the configured issuer). The issuer URL intentionally omits the port (`self.issuer`) while the JWKS fetch URL includes it (`self.host`). Do not conflate them.
+13. The `Authorization` header must use the `"Bearer "` prefix (capital B, trailing space) per RFC 6750. Tokens with other schemes are silently skipped, allowing downstream auth plugins to handle them.
+14. Scope validation requires **all** configured scopes to be present in the token. A backend service account entry without a `scopes` field permits any scope set.
+15. OIDC backend definitions are validated at boot time (`validate_oidc_definitions` in `__init__.py`). An empty `oidc` object, missing `clientId`, a `clientId` that is present but empty, or a `scopes` key that is present but empty (or contains empty strings) causes a startup failure. A service account entry with no `scopes` key at all is valid (means no scope restriction is enforced).
+
+## X.509 / mTLS Authentication
+
+16. X.509 auth requires both a valid subject header and a matching pre-shared key (PSK). The PSK check supports two secrets: `CDN_PRESHARED_KEY` (primary) and `CDN_PRESHARED_KEY_ALT` (rotation). When rotating CDN secrets, set the new value in `CDN_PRESHARED_KEY_ALT` first, then promote it.
+17. The PSK header name is configurable via `HEADER_CERTAUTH_PSK`. If this config value is unset (`None`), or if the named header is absent from the request, `psk_check()` returns `False` and X.509 auth will never succeed.
+18. Client certificate subject/issuer are passed via headers (`x-rh-certauth-cn`, `x-rh-certauth-issuer` by default) set by nginx after `ssl_verify_client`. These headers must only be set by the trusted nginx layer, never by external clients.
+
+## Registry / Basic Auth Authentication
+
+19. Registry auth sends credentials to an external service over mTLS (client cert + key required at startup). The response must contain `{"access": {"pull": "granted"}}` (additional fields in the response body are ignored; only `access.pull == "granted"` is checked).
+20. Registry auth results are cached by `user:sha256(password)` with a configurable TTL (`REGISTRY_AUTH_CACHE_TTL`, default 300s). Changing a password invalidates the cache entry. All outbound requests enforce a timeout (`REGISTRY_SERVICE_TIMEOUT`, default 10s).
+21. Basic Auth usernames use `org_id|username` format. The `|` delimiter is split with `maxsplit=1` to handle usernames that themselves contain the delimiter character.
+
+## SAML Authentication
+
+22. SAML session data is stored server-side in Redis via Flask-Session (`SESSION_TYPE = "redis"`). `SESSION_COOKIE_SECURE = True` is set unconditionally -- cookies are only sent over HTTPS.
+23. The `MockSAMLAssertionView` (`/saml/.../mock/`) is gated by `TESTING` config. It returns 404 in non-test environments. Never set `TESTING=True` in production.
+24. SAML has separate settings paths for "internal" and "private" IdPs (`INTERNAL_SAML_PATH`, `PRIVATE_SAML_PATH`). Each has its own certificate directory. Nginx routes 401 redirects to the correct SAML login based on the `X-Rh-Edge-Host` header value.
+
+## VPN / Network Restrictions
+
+25. VPN-restricted backends (`private: true`) require the `X-Rh-Edge-Host` header. This header is validated with a strict regex that only matches `(internal|private).(console|cloud).(stage|dev.)?redhat.com` with optional `mtls.` prefix.
+26. Environment cross-contamination is blocked: a production host header is rejected in non-production, and vice versa. This is enforced in `HeaderValidator.validate_edge_host_header`.
+27. Source IP filtering uses `X-Forwarded-For` with `HOPS_TO_EDGE` to determine the true client IP. Malformed hop lists result in 403. The `ProxyFix` middleware (`x_for=1`) is applied at the WSGI level.
+
+## Secret Management
+
+28. `SECRET_KEY` is required at import time of `config.py` -- the app refuses to start without it. Never commit it or any PSK/CDN secret to the repository.
+29. `.gitignore` excludes `.env`, `dev-config.py`, `nginx/certs/`, `turnpike/saml/`, and `local/`. Keep credentials, certificates, and SAML configs out of version control.
+30. The `SSO_OIDC_HOST`, `SSO_OIDC_PORT`, `SSO_OIDC_PROTOCOL_SCHEME`, and `SSO_OIDC_REALM` are all required at startup. Missing any of them raises `ValueError` and prevents boot.
+
+## Header Security
+
+31. `nginx/auth_request` passes only explicitly listed headers between nginx and the policy service. Headers the policy service needs are declared in each plugin's `headers_needed` set; headers to forward upstream are in `headers_to_forward`. If your plugin needs a new header, add it to the appropriate set.
+32. The `/auth/` subrequest strips the request body (`proxy_pass_request_body off`). Auth decisions must be based solely on headers, session state, or cached data.
+33. `X-RH-Identity` is base64-encoded JSON constructed by `RHIdentityPlugin`. It is never parsed from an incoming request header in the policy flow -- it is always generated fresh. The `/api/turnpike/identity/` endpoint does decode an incoming `X-Rh-Identity` for debugging but is itself behind auth.
+
+## CI & Static Analysis
+
+34. Pre-commit hooks enforce: `black` formatting, `trailing-whitespace`, `end-of-file-fixer`, `debug-statements` (no stray `breakpoint()`/`pdb`), and `mypy` type checking.
+35. Container images are scanned on pushes and PRs targeting the `main`, `master`, or `security-compliance` branches via the `ConsoleDot Platform Security Scan` workflow using Anchore Grype (vulnerability scan) and Syft (SBOM generation). All three images (web, nginx, nginx-prometheus) are scanned independently.
+36. Pin dependency versions in `Pipfile` (most packages use exact pins). Use `Pipfile.lock` for reproducible builds. The base image is UBI 9 minimal with a specific tag.
+
+## Testing Auth Plugins
+
+37. Test configurations must set `CACHE_TYPE: "SimpleCache"` (not Redis) and provide their own `SECRET_KEY`, `BACKENDS`, and plugin chains. Use `create_app(test_config)` with an explicit config dict -- never load the production `config.py` in tests.
+38. Each auth plugin test should cover: skip when backend lacks the auth type, skip when credentials are absent, reject on invalid credentials, reject on insufficient authorization, and accept on valid credentials with matching predicates.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -1,0 +1,169 @@
+# Testing Guidelines
+
+## Running Tests
+
+```bash
+# Run all tests (same as CI)
+pytest --disable-pytest-warnings tests/
+
+# Run a single test file
+pytest tests/test_oidc_plugin.py
+
+# Run a single test
+pytest tests/test_oidc_plugin.py::TestMatchingBackends::test_missing_bearer_token
+```
+
+CI runs tests via `konflux-pr-check.sh` on Python 3.11 using `pytest`. Pre-commit hooks (black, mypy, trailing-whitespace, end-of-file-fixer, debug-statements) run separately in GitHub Actions.
+
+## Test Framework and Style
+
+- **unittest.TestCase** is the standard base class. Do not use bare pytest-style test functions (the one exception, `test_pending` in `test_app.py`, is a placeholder).
+- Import `unittest` and use `self.assert*` methods for all assertions.
+- Each test file covers one module or plugin. Name files `tests/test_<module>.py`.
+- Every test method must have a docstring explaining intent.
+
+## App Configuration Pattern
+
+Tests create a real Flask app via `create_app(test_config)` with an inline config dict. There is no shared conftest.py or session-scoped app fixture. Each test class builds its own config in `setUp()` or a helper method.
+
+Required minimum config keys for `create_app`:
+
+```python
+test_config = {
+    "AUTH_DEBUG": True,
+    "AUTH_PLUGIN_CHAIN": [
+        "turnpike.plugins.x509.X509AuthPlugin",
+        "turnpike.plugins.saml.SAMLAuthPlugin",
+    ],
+    "BACKENDS": yaml.safe_load(test_backends_file),  # or inline list
+    "CACHE_TYPE": "SimpleCache",
+    "DEFAULT_RESPONSE_CODE": http.HTTPStatus.INTERNAL_SERVER_ERROR,
+    "HEADER_CERTAUTH_SUBJECT": "subject",
+    "HEADER_CERTAUTH_ISSUER": "issuer",
+    "HEADER_CERTAUTH_PSK": "test-psk",
+    "PLUGIN_CHAIN": [
+        "tests.mocked_plugins.mocked_plugin.MockPlugin",
+    ],
+    "SECRET_KEY": "12345",
+    "TESTING": True,
+}
+```
+
+- OIDC tests additionally require `SSO_OIDC_HOST`, `SSO_OIDC_PORT`, `SSO_OIDC_PROTOCOL_SCHEME`, and `SSO_OIDC_REALM` (accessed directly by `OIDCAuthPlugin.__init__` when instantiated via `AUTH_PLUGIN_CHAIN`).
+- Registry tests additionally require `REGISTRY_SERVICE_URL`, `REGISTRY_SERVICE_CLIENT_CERT_PATH`, `REGISTRY_SERVICE_CLIENT_KEY_PATH`, and `REGISTRY_SERVICE_SSL_VERIFY`.
+- When multiple test classes in the same process assert on log output, set `APP_NAME` to a unique value (e.g. `uuid.uuid4().__str__()`) to avoid log name collisions.
+
+## Backend Fixtures
+
+- YAML fixtures live in `tests/backends/`.
+- `tests/backends/test-backends.yaml` is the primary shared fixture for valid backends.
+- `tests/backends/invalid-configs/` contains one YAML file per invalid configuration scenario (e.g. `oidc-missing-client-id.yaml`). Each file is purpose-built for a single test.
+- For simple tests, define backends inline as Python dicts rather than loading YAML.
+
+## Mock Plugin
+
+`tests/mocked_plugins/mocked_plugin.py` provides `MockPlugin`, a `TurnpikePlugin` subclass that captures the matched backend. Always include it in `PLUGIN_CHAIN` when you need to inspect which backend was matched:
+
+```python
+"PLUGIN_CHAIN": ["tests.mocked_plugins.mocked_plugin.MockPlugin"]
+```
+
+Access it via `self.app.config.get("PLUGIN_CHAIN_OBJS")[0]`.
+
+## Mocking Conventions
+
+### Flask request mocking
+
+Two patterns are used depending on what is being tested:
+
+1. **`mock.patch` the module-level `request`** -- used when testing plugin `.process()` methods directly (not through the Flask test client). This is the pattern used by `VPNPlugin` and `OIDCAuthPlugin` tests:
+   ```python
+   with mock.patch("turnpike.plugins.vpn.request", request_mock):
+       plugin.process(context)
+   ```
+
+2. **`app.test_request_context()`** -- used when testing plugins that rely on Flask's request context proxy being active (e.g. `RegistryAuthPlugin`, `X509AuthPlugin`, `AuthPlugin`):
+   ```python
+   with self.app.test_request_context("/", headers=headers):
+       result = self.plugin.process(context, backend_auth)
+   ```
+
+### External HTTP calls
+
+Mock `requests.get` or `requests.post` at the plugin's module path. Use `side_effect` methods on the test class to simulate different server responses (success, error, unexpected status codes):
+
+```python
+get = mock.Mock(side_effect=self._requests_get_side_effect_success)
+with mock.patch("turnpike.plugins.oidc.oidc.requests.get", get):
+    ...
+```
+
+Define side effects as named methods on the test class (not lambdas) for reusability and readability.
+
+### Mock objects
+
+- Use `mock.Mock` (the class, not an instance) as a lightweight namespace to attach attributes to without call tracking: `context = mock.Mock` then `context.backend = {...}`. This pattern is used in OIDC and matcher tests.
+- Use `mock.Mock()` (instance) when you need call counting or return value control.
+- Use `PolicyContext()` (the real class, from `turnpike.plugin`) when you need a proper context object with typed attributes. This pattern is used in VPN, registry, and auth plugin tests.
+
+### File I/O mocking
+
+For nginx config builder tests, use `mock.mock_open()` to intercept file writes:
+```python
+with mock.patch("configuration_builder.build_config.open", open_mock, create=True):
+    ...
+```
+
+## Log Assertions
+
+Use `self.assertLogs(logger_name, level=...)` as a context manager to verify log output. The logger name is typically `self.app.logger.name` or `vpn_plugin.app.logger.name`. Check `cm.output[0]` (or specific indices) with `assertIn` or `assertTrue`.
+
+## Test Organization by Module
+
+| Test file | What it tests |
+|---|---|
+| `test_config.py` | Backend config validation at app startup (invalid OIDC configs) |
+| `test_matcher.py` | Backend matching by name and by route URL |
+| `test_oidc_plugin.py` | OIDC/JWT auth plugin (token validation, caching, error handling) |
+| `test_registry_plugin.py` | Registry auth plugin (Basic Auth, mTLS, caching) |
+| `test_vpn_plugin.py` | VPN edge-host header validation |
+| `test_header_validator.py` | Edge host header classification (internal/private/prod) |
+| `test_auth_plugin.py` | AuthPlugin fallback behavior when no plugin authenticates |
+| `test_alternative_gateway_secret.py` | Alternative CDN pre-shared key acceptance |
+| `test_backend_validations.py` | Nginx config builder route/origin validation |
+| `test_nginx_config_builder.py` | Nginx location template rendering and file write order |
+| `test_app.py` | Placeholder (single `pass` test) |
+
+## sys.path Adjustments
+
+Some test files append paths manually for the nginx config builder which lives outside the Python package:
+```python
+sys.path.append(os.path.abspath("./nginx"))
+```
+Tests must be run from the repository root directory for these relative paths to resolve.
+
+## Formatting and Linting
+
+- **black**: line length 119, target Python 3.11 (`black -l 119 -t py311`).
+- **mypy**: configured in `mypy.ini` with `ignore_missing_imports = True`.
+- Pre-commit hooks enforce both. CI in `konflux-pr-check.sh` also runs black as a gate.
+
+## pytest Configuration
+
+`pytest.ini` only suppresses `UserWarning`:
+```ini
+[pytest]
+filterwarnings =
+    ignore::UserWarning
+```
+
+No custom markers, plugins, or coverage requirements are configured. There is no coverage threshold enforced in CI.
+
+## What to Test for New Plugins
+
+1. **Skip behavior** -- plugin returns unmodified context when its auth type is absent from the backend.
+2. **Missing/malformed input** -- missing headers, bad tokens, invalid credentials.
+3. **External service errors** -- connection failures, unexpected status codes, invalid response bodies.
+4. **Caching** -- verify that repeated calls with the same input do not re-call external services (check `mock.call_count`).
+5. **Authorization predicate evaluation** -- when the backend has a predicate expression, test both pass and fail cases.
+6. **Log output** -- verify that meaningful log messages are emitted for skip, deny, and error paths.


### PR DESCRIPTION
This PR was generated by the /agent-readiness Claude skill from https://github.com/gwenneg/claude-engineering-toolkit.

https://redhat.atlassian.net/browse/RHCLOUD-46890

## Summary

- Adds 6 domain-specific guideline files (`docs/*-guidelines.md`) covering security, performance, error-handling, API contracts, testing, and integration — each explored and verified against the actual codebase
- Adds `AGENTS.md` as the agent onboarding doc: cross-cutting conventions, project structure, architectural patterns, common pitfalls, and an index to the guideline files
- Adds `CLAUDE.md` (thin Claude Code-specific layer: imports `AGENTS.md`, adds build/test commands)
- Adds `CONTRIBUTING.md` with contribution workflow for humans and agents
- Adds `docs/ARCHITECTURE.md` with design rationale (why nginx auth_request, why two containers, why the plugin chain is dynamic, etc.)
- Adds `.coderabbit.yaml` to configure CodeRabbit to enforce the guideline files during PR reviews
- Updates `README.md` with links to all new documentation

## Test plan

- [ ] Verify guideline files accurately reflect the codebase (spot-check file paths, class names, and rules against source)
- [ ] Confirm `CLAUDE.md` loads correctly in Claude Code (`@AGENTS.md` import resolves)
- [ ] Confirm `.coderabbit.yaml` is picked up by CodeRabbit on the next PR review