### PR TITLE
allow vpn restricted routes to not begin with /public

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The substring matching of `route` and the rewriting to `origin` are the same as 
 rules.
 
 If a route has a key `auth`, then it will require authentication. *If the `auth` key is missing, the default is to forbid
-access unless the route resides under `/public/`* [(see best practices)][route-best-practice]. The `auth` key's value should be a set of key/value
+access unless the route resides under `/public/`* or the route is VPN restricted [(see best practices)][route-best-practice]. The `auth` key's value should be a set of key/value
 pairs representing supported authentication schemes and corresponding authorization rules. At this time, the only
 supported authentication schemes are `saml`, `x509`.
 

--- a/dev-backends.yml
+++ b/dev-backends.yml
@@ -32,7 +32,7 @@
     saml: "True"
     x509: "True"
 - name: vpn_restricted_api
-  route: /public/vpn/echo/
+  route: /api/vpn/echo/
   private: true
   origin: http://echo-server.svc.cluster.local:8080/vpn/echo/
 - name: echo_server_api

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -107,6 +107,8 @@ following rules:
   authentication.
 * If you're exposing a web application with its own HTML interface for app `myapp`, your route should begin with
   `/app/myapp/` - these routes must require authentication.
+* If you're exposing a VPN-restricted route (`private: true`), it does not need to begin with `/public/`. VPN
+  restriction counts as an access control mechanism, so these routes can use any allowed prefix (e.g. `/api/`, `/app/`).
 * If you're exposing a route and really need it to require no authentication at all:
   * You probably should be exposing the route through 3scale. The Turnpike gateway is really for internal associates
     only.

--- a/nginx/configuration_builder/build_config.py
+++ b/nginx/configuration_builder/build_config.py
@@ -62,6 +62,9 @@ def validate_route(backend):
             f"[backend_name: {name}][route: {route}] The back end's route is not part of the allowed routes"
         )
 
+    # Routes must have some sort of restriction like an "auth" block or a "source_ip" block or "private" block. In the case that they do
+    # not have those elements, the first segment of the path must always begin with the allowed "public" segments that
+    # we have configured.
     if ("auth" not in backend and "source_ip" not in backend and not backend.get("private", False)) and (
         first_path_segment not in ALLOWED_NO_AUTH_ROUTES
     ):

--- a/nginx/configuration_builder/build_config.py
+++ b/nginx/configuration_builder/build_config.py
@@ -62,12 +62,11 @@ def validate_route(backend):
             f"[backend_name: {name}][route: {route}] The back end's route is not part of the allowed routes"
         )
 
-    # Routes must have some sort of restriction like an "auth" block or a "source_ip" block. In the case that they do
-    # not have those elements, the first segment of the path must always begin with the allowed "public" segments that
-    # we have configured.
-    if ("auth" not in backend and "source_ip" not in backend) and (first_path_segment not in ALLOWED_NO_AUTH_ROUTES):
+    if ("auth" not in backend and "source_ip" not in backend and not backend.get("private", False)) and (
+        first_path_segment not in ALLOWED_NO_AUTH_ROUTES
+    ):
         raise InvalidBackendDefinitionError(
-            f'[backend_name: {name}] The back end does not have either an "auth" or "source_ip" definitions, nor its route\'s first segment begins with the allowed public segments. Either add an access restriction mechanism, or modify the route so that it begins with one of the allowed public segments'
+            f'[backend_name: {name}] The back end does not have an "auth", "source_ip", or "private" definition, nor does its route\'s first segment begin with the allowed public segments. Either add an access restriction mechanism, or modify the route so that it begins with one of the allowed public segments'
         )
 
 

--- a/tests/test_backend_validations.py
+++ b/tests/test_backend_validations.py
@@ -141,11 +141,6 @@ class TestBackendValidations(unittest.TestCase):
                 origin="http://public-unrestricted-svc.test-namespace.svc.cluster.local:8080/test",
                 private=False,
             ),
-            dict(
-                name="private-null-unrestricted",
-                route="/api/unrestricted",
-                origin="http://public-unrestricted-svc.test-namespace.svc.cluster.local:8080/test",
-            ),
         ]:
             with self.assertRaises(InvalidBackendDefinitionError) as cm:
                 build_config.validate_route(backend)

--- a/tests/test_backend_validations.py
+++ b/tests/test_backend_validations.py
@@ -12,7 +12,7 @@ from configuration_builder import build_config
 class TestBackendValidations(unittest.TestCase):
 
     def test_valid_backends(self):
-        """Tests that no errors are raised when the back ends are correctly defined, including those which only are restricted by a "source_ip"."""
+        """Tests that no errors are raised when the back ends are correctly defined, including those which only are restricted by a "source_ip" or "private" (VPN)."""
         for backend in [
             dict(
                 name="valid-test-1",
@@ -36,6 +36,12 @@ class TestBackendValidations(unittest.TestCase):
                 route="/public/restricted",
                 origin="http://public-restricted.svc.test-namespace.svc.cluster.local:8000/",
                 source_ip="10.0.0.0/24",
+            ),
+            dict(
+                name="valid-test-5-vpn",
+                route="/api/vpn/test",
+                origin="http://vpn-svc.test-namespace.svc.cluster.local:8080/api",
+                private=True,
             ),
         ]:
             try:
@@ -121,18 +127,30 @@ class TestBackendValidations(unittest.TestCase):
         )
 
     def test_restricted_public_routes(self):
-        """Tests that a back end which is not restricted by either "auth" or "source_ip" and that does not have the "public" segment in its route raises an exception."""
+        """Tests that a back end which is not restricted by "auth", "source_ip", or "private" and that does not have the "public" segment in its route raises an exception."""
 
-        backend = dict(
-            name="public-unrestricted",
-            route="/api/unrestricted",
-            origin="http://public-unrestricted-svc.test-namespace.svc.cluster.local:8080/test",
-        )
+        for backend in [
+            dict(
+                name="public-unrestricted",
+                route="/api/unrestricted",
+                origin="http://public-unrestricted-svc.test-namespace.svc.cluster.local:8080/test",
+            ),
+            dict(
+                name="private-false-unrestricted",
+                route="/api/unrestricted",
+                origin="http://public-unrestricted-svc.test-namespace.svc.cluster.local:8080/test",
+                private=False,
+            ),
+            dict(
+                name="private-null-unrestricted",
+                route="/api/unrestricted",
+                origin="http://public-unrestricted-svc.test-namespace.svc.cluster.local:8080/test",
+            ),
+        ]:
+            with self.assertRaises(InvalidBackendDefinitionError) as cm:
+                build_config.validate_route(backend)
 
-        with self.assertRaises(InvalidBackendDefinitionError) as cm:
-            build_config.validate_route(backend)
-
-        self.assertEqual(
-            f'[backend_name: {backend["name"]}] The back end does not have either an "auth" or "source_ip" definitions, nor its route\'s first segment begins with the allowed public segments. Either add an access restriction mechanism, or modify the route so that it begins with one of the allowed public segments',
-            str(cm.exception),
-        )
+            self.assertEqual(
+                f'[backend_name: {backend["name"]}] The back end does not have an "auth", "source_ip", or "private" definition, nor does its route\'s first segment begin with the allowed public segments. Either add an access restriction mechanism, or modify the route so that it begins with one of the allowed public segments',
+                str(cm.exception),
+            )


### PR DESCRIPTION
## Summary
Right now we require vpn restricted routes to begin with `/public` if the route does not contain `auth` or `source_ip` config as well. So a route that is only vpn restricted must be labeled public.. which feels incorrect. This PR removes this limitation

### Testing
This was easy to test locally. To see the issue currently do the following from `main`:
1. in `dev-backends.yml` update the route `vpn_restricted_api` to not start with `/public`
2. start the service: `podman-compose up --build`
3. there will be an error that is thrown when building the nginx locations

To see the fix:
1. in `dev-backends.yml` I configured `vpn_restricted_api` route to not start with `/public`
2. start the service via `podman-compose up --build` -> due to previous step there should be no errors
3. you can hit the route via
```
curl -k https://localhost:8443/api/vpn/echo/ -H "X-Rh-Edge-Host: private.console.redhat.com"
```

### Ticket
https://redhat.atlassian.net/browse/RHCLOUD-47241