### PR TITLE
chore: update UBI9 base images

### DIFF
--- a/.tekton/turnpike-web-pull-request.yaml
+++ b/.tekton/turnpike-web-pull-request.yaml
@@ -216,7 +216,7 @@ spec:
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
           name: use-trusted-artifact
         - computeResources: {}
-          image: registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
+          image: registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
           name: unit-tests
           script: |
             #!/bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
 
 LABEL name="turnpike" \
       summary="Red Hat Insights Turnpike Authentication Gateway" \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
 
 LABEL name="turnpike-nginx" \
       summary="Red Hat Insights Turnpike Nginx Proxy" \

--- a/nginx/Dockerfile-prometheus
+++ b/nginx/Dockerfile-prometheus
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
 
 LABEL name="turnpike-nginx-prometheus" \
       summary="Red Hat Insights Turnpike Nginx Prometheus Exporter" \


### PR DESCRIPTION
## Summary

Update UBI9 container base images to latest available versions from Red Hat Container Catalog.

## Changes

| Dockerfile | Image | Old Tag | New Tag | Health |
|------------|-------|---------|---------|--------|
| `Dockerfile` | `ubi9/ubi-minimal` | `9.8-1780378819` | `9.8-1781496742` | A |
| `Dockerfile` | `ubi9/ubi-minimal` | `9.8-1780378819` | `9.8-1781496742` | A |
| `Dockerfile-prometheus` | `ubi9/ubi-minimal` | `9.8-1780378819` | `9.8-1781496742` | A |

## Motivation

- Keep base images current with security patches
- Maintain compliance with container health requirements
- Reduce technical debt from outdated base images

## Verification

- [ ] Container builds succeed locally
- [ ] CI/CD pipeline passes
- [ ] Application functions correctly with updated base

## References

- [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/)
- Latest tags verified via Pyxis API

## Test Plan

1. Verify container builds complete successfully
2. Run application smoke tests
3. Confirm no regression in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)
