### PR TITLE
docs: update CLAUDE.md and testing guidelines after PR #702

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ pipenv install --dev
 
 # Install pre-commit hooks (run once after clone)
 pre-commit install
+pre-commit install --hook-type commit-msg
 
 # Run tests (from repo root)
 pytest tests/
@@ -24,7 +25,7 @@ FLASK_ENV=development ./run-server.sh
 
 ## Pre-commit Hooks
 
-Hooks run automatically on `git commit`: black (line length 119, py311), trailing-whitespace, end-of-file-fixer, debug-statements, mypy. CI re-runs them via GitHub Actions on every PR. Fix all hook failures before pushing.
+Hooks run automatically on `git commit`: black (line length 119, py311), trailing-whitespace, end-of-file-fixer, debug-statements, mypy, no-ai-coauthor (commit-msg stage). CI re-runs them via GitHub Actions on every PR. Fix all hook failures before pushing.
 
 ## CI (Konflux PR Check)
 

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -132,6 +132,7 @@ Use `self.assertLogs(logger_name, level=...)` as a context manager to verify log
 | `test_alternative_gateway_secret.py` | Alternative CDN pre-shared key acceptance |
 | `test_backend_validations.py` | Nginx config builder route/origin validation |
 | `test_nginx_config_builder.py` | Nginx location template rendering and file write order |
+| `test_logging_config.py` | Log level configuration (LOG_LEVEL override, WEB_ENV-based defaults) |
 | `test_app.py` | Placeholder (single `pass` test) |
 
 ## sys.path Adjustments


### PR DESCRIPTION
## Summary

- Document the `commit-msg` hook install step in CLAUDE.md (`pre-commit install --hook-type commit-msg`)
- Add `no-ai-coauthor` to the listed pre-commit hooks
- Add `test_logging_config.py` to the test organization table in testing guidelines

Follow-up to #702.

## Test plan

- [ ] Docs-only change, no code impact