### PR TITLE
[RHCLOUD-49651] feat: turnpike: eval() of backend predicate strings from BACKENDS_CONFIG_MAP enables arbitrary code execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ scripts/                   # Dev convenience scripts
 
 1. **`config.py` runs at import time** -- new required env vars crash on import, including test collection. Tests must pass a self-contained dict to `create_app(test_config)`.
 2. **Tests must run from the repo root** -- nginx builder tests use relative `sys.path` appends.
-3. **Auth predicates use `eval()`** -- SAML, X.509, and registry rules are Python expressions from YAML config. These are trusted configuration, never user-derived input.
+3. **Auth predicates use `safe_eval()`** -- SAML, X.509, and registry rules are Python expressions from YAML config, validated against an AST allowlist and executed with restricted builtins. Unsafe expressions fail closed (return `False`).
 4. **OIDC issuer vs host URL** -- `issuer` (for JWT `iss` validation) excludes port; `host` (for HTTP calls) includes it.
 5. **No timeout on OIDC HTTP calls** -- known gap; all new outbound calls must include explicit `timeout=`.
 6. **`/auth/` endpoint returns empty bodies** -- nginx ignores `auth_request` response bodies. Never put error details in `policy_view` responses.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ The backends YAML (`/etc/turnpike/backends.yml`) is the single source of truth f
 
 **OIDC HTTP calls have no timeout.** `OIDCAuthPlugin` makes two `requests.get()` calls with no explicit `timeout`. A hanging SSO server blocks a Gunicorn worker indefinitely. The registry plugin correctly sets `timeout=self.request_timeout`. This gap has been documented but not fixed.
 
-**Authorization predicates use `eval()`.** SAML, X.509, and registry auth plugins evaluate Python expressions from backends YAML via `eval()`. Safe only because predicates come from trusted configuration (app-interface MRs), never user input. An `eval()` error in a predicate propagates unhandled.
+**Authorization predicates use `safe_eval()`.** SAML, X.509, and registry auth plugins evaluate Python expressions from backends YAML via `safe_eval()` (in `turnpike/safe_eval.py`). Predicates are validated against an AST allowlist before execution with restricted builtins. Unsafe expressions and runtime errors fail closed (return `False`). Predicates come from trusted configuration (app-interface MRs), never user input.
 
 **No graceful JWKS key rotation detection.** JWKS certificates are cached for 24 hours. If SSO rotates keys, JWTs signed with the new key fail validation until the cache expires.
 

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -118,4 +118,4 @@ The nginx config builder retries the Flask service URL in a loop (`while not res
 
 ## Authorization Predicate Errors
 
-Backend auth predicates are evaluated via `eval(predicate, dict(...))`. If the predicate raises an exception, it propagates unhandled -- there is no try/except around `eval()` calls in `SAMLAuthPlugin`, `X509AuthPlugin`, or `RegistryAuthPlugin`. Predicate expressions must be valid Python that evaluates to a truthy/falsy value given the provided context dict.
+Backend auth predicates are evaluated via `safe_eval()` from `turnpike.safe_eval`. The `safe_eval()` function validates the predicate AST against an allowlist before evaluation, and wraps all execution in try/except -- any parse error, unsafe expression, or runtime exception causes the predicate to fail closed (return `False`) and log the error. Predicate expressions must be valid Python that evaluates to a truthy/falsy value given the provided context dict.

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -16,10 +16,10 @@ Rules and conventions for contributing to Turnpike, the nginx `auth_request` pol
 7. When the entire auth plugin chain completes without authenticating, `AuthPlugin` returns 401. Individual auth plugins should return the context unmodified (not set 401) when they simply do not apply -- the fallback handles the denial.
 8. `PolicyContext.headers` is a mutable dict shared across all plugins. Only add headers you intend the upstream to see. The `X-RH-Identity` header is constructed by `RHIdentityPlugin` and forwarded via nginx `auth_request_set` directives.
 
-## Authorization Predicates (eval)
+## Authorization Predicates (safe_eval)
 
-9. The `saml`, `x509`, and `registry` auth plugins use `eval()` to evaluate backend authorization predicates from the YAML config. The predicate string (e.g., `'x509["subject_dn"].startswith("/CN=allowed")'`) is executed with a restricted namespace containing only the auth data dict. **Never** allow user-controlled input to flow into these predicates. They are trusted configuration, not request data.
-10. OIDC backends do **not** use `eval()`. Authorization is determined by matching `clientId` and `scopes` from the JWT against the backend's `serviceAccounts` list.
+9. The `saml`, `x509`, and `registry` auth plugins use `safe_eval()` (from `turnpike.safe_eval`) to evaluate backend authorization predicates from the YAML config. The predicate string (e.g., `'x509["subject_dn"].startswith("/CN=allowed")'`) is first validated via an AST allowlist, then executed with restricted builtins and only the auth data dict. Unsafe expressions are rejected and the predicate fails closed (returns `False`). **Never** allow user-controlled input to flow into these predicates. They are trusted configuration, not request data.
+10. OIDC backends do **not** use predicate evaluation. Authorization is determined by matching `clientId` and `scopes` from the JWT against the backend's `serviceAccounts` list.
 
 ## OIDC / JWT Authentication
 

--- a/tests/test_safe_eval.py
+++ b/tests/test_safe_eval.py
@@ -1,0 +1,255 @@
+import unittest
+
+from turnpike.safe_eval import safe_eval
+
+
+class TestSafeEvalAllowedPatterns(unittest.TestCase):
+
+    def test_literal_true(self):
+        self.assertTrue(safe_eval("True", {}))
+
+    def test_literal_false(self):
+        self.assertFalse(safe_eval("False", {}))
+
+    def test_simple_comparison(self):
+        result = safe_eval('registry["org_id"] == "999"', dict(registry={"org_id": "999"}))
+        self.assertTrue(result)
+
+    def test_simple_comparison_false(self):
+        result = safe_eval('registry["org_id"] == "999"', dict(registry={"org_id": "123"}))
+        self.assertFalse(result)
+
+    def test_boolean_and(self):
+        result = safe_eval(
+            'x509["subject_dn"] == "/CN=test" and x509["issuer_dn"] == "/O=Red Hat"',
+            dict(x509={"subject_dn": "/CN=test", "issuer_dn": "/O=Red Hat"}),
+        )
+        self.assertTrue(result)
+
+    def test_boolean_or(self):
+        result = safe_eval(
+            'x509["subject_dn"] == "/CN=a" or x509["subject_dn"] == "/CN=b"',
+            dict(x509={"subject_dn": "/CN=b"}),
+        )
+        self.assertTrue(result)
+
+    def test_not_operator(self):
+        result = safe_eval("not False", {})
+        self.assertTrue(result)
+
+    def test_set_intersection(self):
+        result = safe_eval(
+            'set(user["roles"]).intersection(set(["admin", "editor"]))',
+            dict(user={"roles": ["admin", "viewer"]}),
+        )
+        self.assertTrue(result)
+
+    def test_set_intersection_empty(self):
+        result = safe_eval(
+            'set(user["roles"]).intersection(set(["admin", "editor"]))',
+            dict(user={"roles": ["viewer"]}),
+        )
+        self.assertFalse(result)
+
+    def test_len_call(self):
+        result = safe_eval('len(user["roles"]) > 0', dict(user={"roles": ["admin"]}))
+        self.assertTrue(result)
+
+    def test_in_operator(self):
+        result = safe_eval('"admin" in user["roles"]', dict(user={"roles": ["admin", "viewer"]}))
+        self.assertTrue(result)
+
+    def test_string_with_special_chars(self):
+        result = safe_eval(
+            'x509["subject_dn"] == "/CN=test/O=Red Hat, Inc."',
+            dict(x509={"subject_dn": "/CN=test/O=Red Hat, Inc."}),
+        )
+        self.assertTrue(result)
+
+    def test_dict_get_method(self):
+        result = safe_eval('user.get("role", "none") == "admin"', dict(user={"role": "admin"}))
+        self.assertTrue(result)
+
+    def test_string_startswith(self):
+        result = safe_eval('x509["subject_dn"].startswith("/CN=")', dict(x509={"subject_dn": "/CN=test"}))
+        self.assertTrue(result)
+
+    def test_nested_subscript(self):
+        result = safe_eval('user["data"]["org"] == "redhat"', dict(user={"data": {"org": "redhat"}}))
+        self.assertTrue(result)
+
+    def test_list_literal(self):
+        result = safe_eval('"admin" in ["admin", "editor"]', {})
+        self.assertTrue(result)
+
+    def test_int_comparison(self):
+        result = safe_eval('int(registry["org_id"]) > 100', dict(registry={"org_id": "200"}))
+        self.assertTrue(result)
+
+    def test_dict_literal_default(self):
+        result = safe_eval('user.get("role", "none") == "none"', dict(user={}))
+        self.assertTrue(result)
+
+    def test_empty_dict_literal(self):
+        result = safe_eval("len({}) == 0", {})
+        self.assertTrue(result)
+
+    def test_if_expression(self):
+        result = safe_eval('True if user["role"] == "admin" else False', dict(user={"role": "admin"}))
+        self.assertTrue(result)
+
+
+class TestSafeEvalRejectedPatterns(unittest.TestCase):
+
+    def test_import_rejected(self):
+        result = safe_eval('__import__("os").system("echo pwned")', {})
+        self.assertFalse(result)
+
+    def test_dunder_class_rejected(self):
+        result = safe_eval("().__class__.__bases__[0].__subclasses__()", {})
+        self.assertFalse(result)
+
+    def test_dunder_attribute_rejected(self):
+        result = safe_eval("x509.__class__", dict(x509={}))
+        self.assertFalse(result)
+
+    def test_exec_rejected(self):
+        result = safe_eval('exec("import os")', {})
+        self.assertFalse(result)
+
+    def test_eval_in_predicate_rejected(self):
+        result = safe_eval('eval("True")', {})
+        self.assertFalse(result)
+
+    def test_open_rejected(self):
+        result = safe_eval('open("/etc/passwd")', {})
+        self.assertFalse(result)
+
+    def test_lambda_rejected(self):
+        result = safe_eval("(lambda: True)()", {})
+        self.assertFalse(result)
+
+    def test_syntax_error_returns_false(self):
+        result = safe_eval("this is not valid python !!!", {})
+        self.assertFalse(result)
+
+    def test_unknown_variable_rejected(self):
+        result = safe_eval('os.system("echo pwned")', {})
+        self.assertFalse(result)
+
+    def test_getattr_rejected(self):
+        result = safe_eval('getattr(x509, "subject_dn")', dict(x509={}))
+        self.assertFalse(result)
+
+    def test_type_call_rejected(self):
+        result = safe_eval("type(x509)", dict(x509={}))
+        self.assertFalse(result)
+
+    def test_pow_operator_rejected(self):
+        result = safe_eval("2 ** 100", {})
+        self.assertFalse(result)
+
+    def test_comprehension_rejected(self):
+        result = safe_eval("[x for x in [1,2,3]]", {})
+        self.assertFalse(result)
+
+    def test_walrus_operator_rejected(self):
+        result = safe_eval("(x := True)", {})
+        self.assertFalse(result)
+
+    def test_sandbox_escape_via_subclasses(self):
+        result = safe_eval(
+            "().__class__.__bases__[0].__subclasses__()",
+            {},
+        )
+        self.assertFalse(result)
+
+    def test_builtins_access_rejected(self):
+        result = safe_eval("__builtins__", {})
+        self.assertFalse(result)
+
+
+class TestSafeEvalRuntimeErrors(unittest.TestCase):
+    """Verify that runtime errors during eval() fail closed (return False)."""
+
+    def test_keyerror_returns_false(self):
+        result = safe_eval('registry["nonexistent"]', dict(registry={}))
+        self.assertFalse(result)
+
+    def test_attributeerror_returns_false(self):
+        result = safe_eval('x509["dn"].startswith("/CN=")', dict(x509={"dn": None}))
+        self.assertFalse(result)
+
+    def test_typeerror_returns_false(self):
+        result = safe_eval('len(registry["count"]) > 0', dict(registry={"count": 42}))
+        self.assertFalse(result)
+
+    def test_zero_division_returns_false(self):
+        result = safe_eval("1 / 0 > 0", {})
+        self.assertFalse(result)
+
+    def test_non_string_expression_returns_false(self):
+        result = safe_eval(123, {})
+        self.assertFalse(result)
+
+    def test_null_byte_expression_returns_false(self):
+        result = safe_eval("True\x00", {})
+        self.assertFalse(result)
+
+
+class TestSafeEvalEdgeCases(unittest.TestCase):
+    """Edge cases: None values, empty collections, missing keys, deep nesting."""
+
+    def test_none_variable_value(self):
+        result = safe_eval("x is None", {"x": None})
+        self.assertTrue(result)
+
+    def test_empty_string_comparison(self):
+        result = safe_eval('user["name"] == ""', dict(user={"name": ""}))
+        self.assertTrue(result)
+
+    def test_empty_list_variable(self):
+        result = safe_eval('len(user["roles"]) > 0', dict(user={"roles": []}))
+        self.assertFalse(result)
+
+    def test_missing_dict_key_returns_false(self):
+        result = safe_eval('user["missing_key"] == "value"', dict(user={}))
+        self.assertFalse(result)
+
+    def test_deeply_nested_boolean(self):
+        result = safe_eval(
+            'x == "a" and (y == "b" or (z == "c" and w == "d"))',
+            {"x": "a", "y": "b", "z": "c", "w": "d"},
+        )
+        self.assertTrue(result)
+
+    def test_backend_name_in_logs(self):
+        result = safe_eval('registry["bad_key"]', dict(registry={}), backend_name="my-service")
+        self.assertFalse(result)
+
+
+class TestSafeEvalBackwardCompatibility(unittest.TestCase):
+    """Tests using predicate patterns found in actual backend configs."""
+
+    def test_saml_true_predicate(self):
+        self.assertTrue(safe_eval("True", dict(user={"name": ["alice"]})))
+
+    def test_x509_true_predicate(self):
+        self.assertTrue(safe_eval("True", dict(x509={"subject_dn": "/CN=test"})))
+
+    def test_registry_true_predicate(self):
+        self.assertTrue(safe_eval("True", dict(registry={"org_id": "123"})))
+
+    def test_registry_org_id_check(self):
+        result = safe_eval(
+            'registry["org_id"] == "999"',
+            dict(registry={"org_id": "999", "username": "alice"}),
+        )
+        self.assertTrue(result)
+
+    def test_x509_dn_with_commas_and_slashes(self):
+        result = safe_eval(
+            'x509["subject_dn"] == "/CN=service/OU=Engineering/O=Red Hat, Inc./C=US"',
+            dict(x509={"subject_dn": "/CN=service/OU=Engineering/O=Red Hat, Inc./C=US"}),
+        )
+        self.assertTrue(result)

--- a/turnpike/plugins/registry.py
+++ b/turnpike/plugins/registry.py
@@ -6,6 +6,7 @@ import requests
 from flask import request
 
 from turnpike import cache
+from turnpike.safe_eval import safe_eval
 from ..plugin import TurnpikeAuthPlugin
 
 
@@ -133,7 +134,7 @@ class RegistryAuthPlugin(TurnpikeAuthPlugin):
         context.auth = dict(auth_data=auth_data, auth_plugin=self)
 
         predicate = backend_auth["registry"]
-        authorized = eval(predicate, dict(registry=auth_data))
+        authorized = safe_eval(predicate, dict(registry=auth_data), backend_name=context.backend.get("name"))
         if not authorized:
             context.status_code = HTTPStatus.FORBIDDEN
 

--- a/turnpike/plugins/saml.py
+++ b/turnpike/plugins/saml.py
@@ -1,5 +1,7 @@
 from flask import current_app, session
 
+from turnpike.safe_eval import safe_eval
+
 from ..plugin import TurnpikeAuthPlugin
 
 
@@ -29,7 +31,7 @@ class SAMLAuthPlugin(TurnpikeAuthPlugin):
             )
 
             predicate = backend_auth["saml"]
-            authorized = eval(predicate, dict(user=auth_dict))
+            authorized = safe_eval(predicate, dict(user=auth_dict), backend_name=context.backend.get("name"))
             if not authorized:
                 context.status_code = 403
 

--- a/turnpike/plugins/x509.py
+++ b/turnpike/plugins/x509.py
@@ -1,6 +1,8 @@
 import logging
 from flask import request
 
+from turnpike.safe_eval import safe_eval
+
 from ..plugin import TurnpikeAuthPlugin
 
 
@@ -56,7 +58,7 @@ class X509AuthPlugin(TurnpikeAuthPlugin):
             self.app.logger.debug(f"X509 auth_data: {auth_data}")
             context.auth = dict(auth_data=auth_data, auth_plugin=self)
             predicate = backend_auth["x509"]
-            authorized = eval(predicate, dict(x509=auth_data))
+            authorized = safe_eval(predicate, dict(x509=auth_data), backend_name=context.backend.get("name"))
             if not authorized:
                 context.status_code = 403
         return context

--- a/turnpike/safe_eval.py
+++ b/turnpike/safe_eval.py
@@ -1,0 +1,152 @@
+import ast
+import logging
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_NAMES = frozenset({"set", "len", "str", "int"})
+
+_ALLOWED_BUILTINS = {"set": set, "len": len, "str": str, "int": int}
+
+_ALLOWED_BINOPS = (
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.BitOr,
+    ast.BitAnd,
+    ast.BitXor,
+)
+
+_SAFE_METHODS = frozenset(
+    {
+        "intersection",
+        "union",
+        "difference",
+        "issubset",
+        "issuperset",
+        "isdisjoint",
+        "lower",
+        "upper",
+        "strip",
+        "startswith",
+        "endswith",
+        "get",
+        "keys",
+        "values",
+        "items",
+    }
+)
+
+
+class _UnsafeExpression(Exception):
+    pass
+
+
+def _validate_node(node, variable_names):
+    match node:
+        case ast.Expression():
+            _validate_node(node.body, variable_names)
+
+        case ast.Constant():
+            pass
+
+        case ast.Name():
+            if node.id not in _ALLOWED_NAMES and node.id not in variable_names:
+                raise _UnsafeExpression(f"disallowed name: {node.id}")
+
+        case ast.BoolOp():
+            for value in node.values:
+                _validate_node(value, variable_names)
+
+        case ast.BinOp():
+            if not isinstance(node.op, _ALLOWED_BINOPS):
+                raise _UnsafeExpression(f"disallowed operator: {type(node.op).__name__}")
+            _validate_node(node.left, variable_names)
+            _validate_node(node.right, variable_names)
+
+        case ast.UnaryOp():
+            _validate_node(node.operand, variable_names)
+
+        case ast.Compare():
+            _validate_node(node.left, variable_names)
+            for comparator in node.comparators:
+                _validate_node(comparator, variable_names)
+
+        case ast.Subscript():
+            _validate_node(node.value, variable_names)
+            _validate_node(node.slice, variable_names)
+
+        case ast.List() | ast.Tuple() | ast.Set():
+            for elt in node.elts:
+                _validate_node(elt, variable_names)
+
+        case ast.Dict():
+            for key in node.keys:
+                if key is not None:
+                    _validate_node(key, variable_names)
+            for val in node.values:
+                _validate_node(val, variable_names)
+
+        case ast.Call():
+            if isinstance(node.func, ast.Name):
+                if node.func.id not in _ALLOWED_NAMES:
+                    raise _UnsafeExpression(f"disallowed function: {node.func.id}")
+            elif isinstance(node.func, ast.Attribute):
+                _validate_attribute(node.func, variable_names)
+            else:
+                raise _UnsafeExpression(f"disallowed call type: {type(node.func).__name__}")
+            for arg in node.args:
+                _validate_node(arg, variable_names)
+            for kw in node.keywords:
+                _validate_node(kw.value, variable_names)
+
+        case ast.Attribute():
+            _validate_attribute(node, variable_names)
+
+        case ast.IfExp():
+            _validate_node(node.test, variable_names)
+            _validate_node(node.body, variable_names)
+            _validate_node(node.orelse, variable_names)
+
+        case _:
+            raise _UnsafeExpression(f"disallowed node type: {type(node).__name__}")
+
+
+def _validate_attribute(node, variable_names):
+    if node.attr.startswith("_"):
+        raise _UnsafeExpression(f"disallowed attribute: {node.attr}")
+    if node.attr not in _SAFE_METHODS:
+        raise _UnsafeExpression(f"disallowed method: {node.attr}")
+    _validate_node(node.value, variable_names)
+
+
+def safe_eval(expression, variables, backend_name=None):
+    label = f"backend {backend_name}" if backend_name else "unknown backend"
+
+    if expression == "True":
+        return True
+    if expression == "False":
+        return False
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except (SyntaxError, TypeError, ValueError):
+        logger.error("Predicate is not valid Python for %s: %s", label, expression)
+        return False
+
+    try:
+        _validate_node(tree, frozenset(variables.keys()))
+    except _UnsafeExpression as exc:
+        logger.error("Predicate rejected for %s (%s): %s", label, exc, expression)
+        return False
+
+    eval_globals = {"__builtins__": {}}
+    eval_globals.update(_ALLOWED_BUILTINS)
+    eval_globals.update(variables)
+    try:
+        return eval(compile(tree, "<predicate>", "eval"), eval_globals)
+    except Exception:
+        logger.error("Predicate evaluation failed for %s: %s", label, expression, exc_info=True)
+        return False


### PR DESCRIPTION
## Summary

- Replace unsafe `eval()` calls in three auth plugins with a safe expression evaluator to eliminate arbitrary code execution risk from BACKENDS_CONFIG_MAP predicates
- Introduce `turnpike/safe_eval.py` implementing custom AST validation via `ast.parse()` + `_validate_node()` allowlist, followed by `eval()` with `{"__builtins__": {}}` -- two independent safety layers (defense in depth)
- Add comprehensive tests covering valid predicates, malicious injection attempts, and error handling
- Update guideline docs (security, error-handling, ARCHITECTURE, AGENTS) to reference `safe_eval()` instead of raw `eval()`

## Changes

**Security fix (plugins)**
- `turnpike/plugins/registry.py`, `saml.py`, `x509.py`: replaced `eval(predicate, {var: value})` with `safe_eval(predicate, {var: value}, backend_name=context.backend.get("name"))` for backend auth predicates

**Safe evaluation module**
- `turnpike/safe_eval.py`: new module exporting `safe_eval()` function that validates predicate AST against an allowlist of safe node types before executing with restricted builtins (`{"__builtins__": {}}`). Blocks imports, dunder attribute access, disallowed functions, `ast.Pow` (DoS hardening), and all builtins except `set`, `len`, `str`, `int`. Supports dict literals (`ast.Dict`) for patterns like `user.get("role", {})`. All error paths return `False` (fail-closed design).

**Documentation updates**
- `docs/security-guidelines.md`, `docs/error-handling-guidelines.md`, `docs/ARCHITECTURE.md`, `AGENTS.md`: updated to reference `safe_eval()` and describe the fail-closed behavior

**Test coverage**
- `tests/test_safe_eval.py`: 255 lines covering valid predicates (comparisons, boolean ops, dict/list access, dict literals), malicious payloads (`__import__`, file I/O, exec, `**` operator), syntax errors, and runtime exceptions

## Review guidance

Focus on the AST allowlist in `safe_eval.py` -- verify that all blocked operations (imports, file access, exec, power operator) are covered and that legitimate predicate patterns (comparisons, boolean logic, container indexing, dict get with default) remain functional.

## Test plan

- Unit tests verify all three attack vectors from the JIRA ticket (import, open, exec) now return `False`
- Power operator (`**`) rejected to prevent DoS via exponential computation
- Dict literals allowed for forward-compatibility with `get()` default patterns
- Existing predicate patterns from production configs (string comparisons, boolean logic, dict key access) pass validation
- Pre-commit hooks (black, mypy) pass
- Manual verification: existing backend YAML predicates continue to work unchanged

JIRA: https://redhat.atlassian.net/browse/RHCLOUD-49651